### PR TITLE
FS-4557: Feature - Form Runner & Designer - Save current form before go forward

### DIFF
--- a/runner/src/server/plugins/engine/models/AdapterFormModel.ts
+++ b/runner/src/server/plugins/engine/models/AdapterFormModel.ts
@@ -12,7 +12,6 @@ import {
 
 import {FormSubmissionState} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/types";
 import {
-    PageController,
     PageControllerBase
 } from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/pageControllers";
 import {
@@ -28,6 +27,7 @@ import {AdapterSchema} from "@communitiesuk/model";
 import {AdapterSummaryPageController} from "../page-controllers/AdapterSummaryPageController";
 import {ControllerNameResolver} from "../page-controllers/ControllerNameResolver";
 import {EvaluationContext} from "./EvaluationContext";
+import {DefaultPageController} from "../page-controllers/DefaultPageController";
 
 
 export class AdapterFormModel {
@@ -43,7 +43,6 @@ export class AdapterFormModel {
     options: any;
     name: any;
     values: any;
-    DefaultPageController: any = PageController;
     /** the id of the form used for the first url parameter eg localhost:3009/test */
     basePath: string;
     conditions: Record<string, ExecutableCondition> | {};
@@ -90,12 +89,6 @@ export class AdapterFormModel {
         this.options = options;
         this.name = def.name;
         this.values = result.value;
-
-        if (options.defaultPageController) {
-            this.DefaultPageController = ControllerNameResolver.getPageController(
-                options.defaultPageController
-            );
-        }
 
         this.basePath = options.basePath;
 
@@ -171,16 +164,9 @@ export class AdapterFormModel {
             if (!PageController) {
                 throw new Error(`PageController for ${pageDef.controller} not found`);
             }
-
             return new PageController(this, pageDef);
         }
-
-        if (this.DefaultPageController) {
-            const DefaultPageController = this.DefaultPageController;
-            return new DefaultPageController(this, pageDef);
-        }
-        // @ts-ignore
-        return new PageControllerBase(this, pageDef);
+        return new DefaultPageController(this, pageDef);
     }
 
     /**

--- a/runner/src/server/plugins/engine/page-controllers/AdapterSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/AdapterSummaryPageController.ts
@@ -67,6 +67,9 @@ export class AdapterSummaryPageController extends SummaryPageController {
             const model = this.model;
             //@ts-ignore
             const state = await cacheService.getState(request);
+            state.metadata.isSummaryPageSubmit = true;
+            //@ts-ignore
+            await cacheService.mergeState(request, { ...state });
             //@ts-ignore
             const summaryViewModel = new AdapterSummaryViewModel(this.title, model, state, request);
             this.setFeedbackDetails(summaryViewModel, request);

--- a/runner/src/server/plugins/engine/page-controllers/DefaultPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/DefaultPageController.ts
@@ -29,8 +29,15 @@ export class DefaultPageController extends PageController {
             let relevantState = this.getConditionEvaluationContext(this.model, savedState);
             //@ts-ignore
             await cacheService.mergeState(request, {webhookData: summaryViewModel.validatedWebhookData,});
-            //@ts-ignore
-            await statusService.outputRequests(request);
+
+            const startPage = this.model.def.startPage;
+            const isStartPage = this.path === startPage;
+
+            if (!isStartPage) {
+                //@ts-ignore
+                await statusService.outputRequests(request);
+            }
+
             return this.proceed(request, h, relevantState);
         };
     }

--- a/runner/src/server/plugins/engine/page-controllers/DefaultPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/DefaultPageController.ts
@@ -1,0 +1,37 @@
+import {PageController} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/pageControllers";
+import {HapiRequest, HapiResponseToolkit} from "../../../types";
+import {AdapterFormModel} from "../models/AdapterFormModel";
+import {AdapterSummaryViewModel} from "../models/AdapterSummaryViewModel";
+
+export class DefaultPageController extends PageController {
+
+    constructor(model: AdapterFormModel, pageDef: any) {
+        //@ts-ignore
+        super(model, pageDef);
+    }
+
+    makePostRouteHandler() {
+        return async (request: HapiRequest, h: HapiResponseToolkit) => {
+            const response = await this.handlePostRequest(request, h);
+            if (response?.source?.context?.errors) {
+                return response;
+            }
+            const {cacheService, statusService} = request.services([]);
+            //@ts-ignore
+            const state = await cacheService.getState(request);
+            state.metadata.isSummaryPageSubmit = false;
+            const model = this.model;
+            //@ts-ignore
+            const summaryViewModel = new AdapterSummaryViewModel(this.title, model, state, request);
+            //@ts-ignore
+            const savedState = await cacheService.getState(request);
+            //This is required to ensure we don't navigate to an incorrect page based on stale state values
+            let relevantState = this.getConditionEvaluationContext(this.model, savedState);
+            //@ts-ignore
+            await cacheService.mergeState(request, {webhookData: summaryViewModel.validatedWebhookData,});
+            //@ts-ignore
+            await statusService.outputRequests(request);
+            return this.proceed(request, h, relevantState);
+        };
+    }
+}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-4557 

Summary: 

As a user I need to save form filled content in a given api location.

Description:

When form has been created using the form designer there are few different ways to output the content of the forms data, with this JIRA we are planing to give new way to save the content and content will be saved each form that you filled in and those data will be persisted in a given api location.

Scope:

This should allow to get a link or a config text to determine the location in the runtime of the save, and if config used it should resolve the link from the configurations that we provide.

Once out put is added each form should call the end point with the data to save.

Validate the output configurations.
