### PR TITLE
FS-3664 Read-only summary flag on the summary page

### DIFF
--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -14,6 +14,7 @@ import {UtilHelper} from "../../utils/UtilHelper";
 export class SummaryPageController extends PageController {
 
     isEligibility: boolean = false;
+    isReadOnlySummary: boolean;
 
     constructor(model: AdapterFormModel, pageDef: any) {
         // @ts-ignore
@@ -46,6 +47,11 @@ export class SummaryPageController extends PageController {
             }
             if (state["metadata"] && state["metadata"]["has_eligibility"]) {
                 this.isEligibility = state["metadata"]["has_eligibility"];
+                this.backLinkText = UtilHelper.getBackLinkText(true, this.model.def?.metadata?.isWelsh);
+                this.backLink = state.callback?.returnUrl;
+            }
+            if (state["metadata"] && state["metadata"]["is_read_only_summary"]) {
+                this.isReadOnlySummary = true;
                 this.backLinkText = UtilHelper.getBackLinkText(true, this.model.def?.metadata?.isWelsh);
                 this.backLink = state.callback?.returnUrl;
             }

--- a/runner/src/server/views/partials/summary-detail.html
+++ b/runner/src/server/views/partials/summary-detail.html
@@ -1,8 +1,8 @@
 {% from "./summary-row.html" import summaryRow %}
 
-{% macro summaryDetail(data) %}
+{% macro summaryDetail(data, isReadOnlySummary=false) %}
     {%  set isRepeatableSection = (data.items[0] | isArray) %}
-    {% if not isRepeatableSection %}
+    {% if not isRepeatableSection and not isReadOnlySummary %}
         <h2 class="govuk-heading-m">{{data.title}}</h2>
     {% endif %}
   <dl class="govuk-summary-list">
@@ -14,7 +14,7 @@
                 {{ summaryRow(repeated) }}
             {% endfor %}
         {% else %}
-          {{ summaryRow(item, data.notSuppliedText, data.changeText) }}
+          {{ summaryRow(item, data.notSuppliedText, data.changeText, isReadOnlySummary) }}
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/runner/src/server/views/partials/summary-row.html
+++ b/runner/src/server/views/partials/summary-row.html
@@ -1,4 +1,4 @@
-{% macro summaryRow(item, notSuppliedText, changeText) %}
+{% macro summaryRow(item, notSuppliedText, changeText, isReadOnlySummary=false) %}
 <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
         {{item.label}}
@@ -47,9 +47,11 @@
         {% endif %}
     </dd>
     <dd class="govuk-summary-list__actions">
+        {% if not isReadOnlySummary %}
         <a class="govuk-link" href="{{item.url}}">
             {{changeText}}<span class="govuk-visually-hidden"> {{item.label}}</span>
         </a>
+        {% endif %}
     </dd>
 </div>
 {% endmacro %}

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -3,6 +3,8 @@
 {% from "button/macro.njk" import govukButton %}
 {% extends 'layout.html' %}
 
+{% set pageTitle = pageTitle if not page.isReadOnlySummary else "View your answers" %}
+
 {% block beforeContent %}
     {{ govukPhaseBanner({
         tag: {
@@ -10,10 +12,10 @@
         },
         html: "This is a new service."
     }) }}
-    {% if page.isEligibility %}
+    {% if page.isEligibility or page.isReadOnlySummary %}
         {{ govukBackLink({
             href: page.backLink,
-            text: page.backLinkText
+            text: page.backLinkText if not page.isReadOnlySummary else "Back to application for funding overview"
         }) }}
     {% endif %}
 {% endblock %}
@@ -21,6 +23,10 @@
     <div class="govuk-main-wrapper">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
+                {% set hasMultipleSections = (details and details.length > 1 and details[0].items[0] | isArray) %}
+                {% if not hasMultipleSections %}
+                <span class="govuk-caption-l">{{ details[0].title }}</span>
+                {% endif %}
                 <h1 class="govuk-heading-l">
                     {% if callback and callback.title %}
                         {{ callback.title }}
@@ -28,7 +34,6 @@
                         {{ pageTitle }}
                     {% endif %}
                 </h1>
-
                 {% if callback and callback.message %}
                     <div class="govuk-inset-text">
                         {{ callback.message }}
@@ -45,8 +50,12 @@
                     </div>
                 {% endif %}
 
+                {% if isReadOnlySummary %}
+                <p class="govuk-body">You cannot change your answers.</p>
+                {% endif %}
+
                 {% for detail in details %}
-                    {{ summaryDetail(detail) }}
+                    {{ summaryDetail(detail, page.isReadOnlySummary) }}
                 {% endfor %}
 
                 {% if fees and fees.details|length %}
@@ -61,7 +70,7 @@
                         card.</p>
                 {% endif %}
 
-                {% if not result.error %}
+                {% if not result.error and not page.isReadOnlySummary %}
                     <form method="post" enctype="multipart/form-data" autocomplete="off" novalidate>
                         <input type="hidden" name="crumb" value="{{ crumb }}"/>
 


### PR DESCRIPTION
### Change description
This introduces a new flag `is_read_only_summary` that can be passed in the existing `metadata` payload when instantiating a new form. This instructs the summary page to not show "Change" links on the questions summary list and provides a direct back link.

Currently this fixes the back link and page title text for the summary page according to if the flag is set but it would be preferable for these values to be set using options bassed in my the service requesting a new form rather than fixed in the form logic -- if there are existing `options` payloads for customising this we should move to use those.

I'm applying the change to the existing custom form builder as well as the newer form builder adpater to not be blocked on deployments as the new patterns gains maturity and is released in different environments.

Note it doesn't look like individual flags like this are currently covered by tests even though they can change the behaviour of the server, I'll look to do this in lining up with the methodology used by the newer form builder adapter.

This change should have parity with https://github.com/communitiesuk/digital-form-builder/pull/551

### Screenshots of UI changes
![image](https://github.com/user-attachments/assets/a28dd592-37e6-44ff-97ef-4a7099d084bb)
