### PR TITLE
FS-3824: MarkAsComplete and Remove Welsh added

### DIFF
--- a/runner/locales/cy.json
+++ b/runner/locales/cy.json
@@ -1,6 +1,8 @@
 {
   "viewAllApplications": "Eich ceisiadau",
   "signOut": "Allgofnodi",
+  "markAsComplete": "A ydych chi eisiau marcio bod yr adran hon wedi'i chwblhau?",
+  "removeText": "Dileu",
   "validation": {
     "required": "{#label} is required",
     "max": "{#label} must be {#limit} characters or less",

--- a/runner/locales/en.json
+++ b/runner/locales/en.json
@@ -1,6 +1,8 @@
 {
   "viewAllApplications": "View all applications",
   "signOut": "Sign out",
+  "markAsComplete": "Do you want to mark this section as complete i8n?",
+  "removeText": "Remove",
   "validation": {
     "required": "{#label} is required",
     "max": "{#label} must be {#limit} characters or less",

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -178,7 +178,7 @@ export class RepeatingFieldPageController extends PageController {
                     }
                 );
 
-                this.addRowsToViewContext(response, state);
+                this.addRowsToViewContext(response, state, request);
                 return response;
             }
 
@@ -207,10 +207,10 @@ export class RepeatingFieldPageController extends PageController {
         };
     }
 
-    addRowsToViewContext(response, state) {
+    addRowsToViewContext(response, state, request) {
         let rows = {};
         if (this.options!.summaryDisplayMode!.samePage) {
-            rows = this.summary.buildRows(this.getPartialState(state), response);
+            rows = this.summary.buildRows(this.getPartialState(state), response, request);
             response.source.context.details = {
                 //@ts-ignore
                 headings: this.inputComponent.options.columnTitles,
@@ -346,7 +346,7 @@ export class RepeatingFieldPageController extends PageController {
                 const {adapterCacheService} = request.services([]);
                 //@ts-ignore
                 const state = await adapterCacheService.getState(request);
-                this.addRowsToViewContext(response, state);
+                this.addRowsToViewContext(response, state, request);
                 return response;
             }
 

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingSummaryPageController.ts
@@ -57,7 +57,7 @@ export class RepeatingSummaryPageController extends PageController {
             //@ts-ignore
             await adapterCacheService.mergeState(request, {progress});
 
-            const viewModel = this.getViewModel(state);
+            const viewModel = this.getViewModel(state, request);
             //@ts-ignore
             viewModel.crumb = request.plugins.crumb;
 
@@ -94,7 +94,7 @@ export class RepeatingSummaryPageController extends PageController {
         };
     };
 
-    getViewModel(formData) {
+    getViewModel(formData, request) {
         const baseViewModel = super.getViewModel(formData);
         let rows;
         const answers = this.getPartialState(formData);
@@ -105,7 +105,8 @@ export class RepeatingSummaryPageController extends PageController {
             rows = this.buildTextFieldRows(
                 answers,
                 formData.metadata.form_session_identifier,
-                orderedNames
+                orderedNames,
+                request
             );
             return {
                 ...baseViewModel,
@@ -122,7 +123,7 @@ export class RepeatingSummaryPageController extends PageController {
         };
     }
 
-    buildRows(state, response) {
+    buildRows(state, response, request) {
         let form_session_identifier =
             response.request.query.form_session_identifier ?? "";
 
@@ -133,7 +134,8 @@ export class RepeatingSummaryPageController extends PageController {
             return this.buildTextFieldRows(
                 state,
                 form_session_identifier,
-                orderedNames
+                orderedNames,
+                request
             );
         }
         return this.getRowsFromAnswers(state, form_session_identifier);
@@ -214,6 +216,7 @@ export class RepeatingSummaryPageController extends PageController {
         answers,
         form_session_identifier,
         orderedNames,
+        request,
         view = false
     ) {
         const {title = ""} = this.inputComponent;
@@ -235,7 +238,7 @@ export class RepeatingSummaryPageController extends PageController {
                         form_session_identifier ? form_session_identifier : ``
                     }`,
                     //@ts-ignore
-                    text: this.options.customText?.removeText ?? "Remove",
+                    text: this.options.customText?.removeText ?? request.i18n.__('removeText'),
                     visuallyHiddenText: title,
                 },
                 values: [],

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -103,7 +103,7 @@
                                 <fieldset class="govuk-fieldset">
                                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                                         <h1 class="govuk-fieldset__heading">
-                                            Do you want to mark this section as complete?
+                                            {{ i18nGetTranslation("markAsComplete") }}
                                         </h1>
                                     </legend>
                                     <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FS-3824
https://mhclgdigital.atlassian.net/browse/FS-2023

### Change description
- Welsh translation added for Mark as complete label at the summary page and for "Remove" option in the build text field component

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Select Welsh language, Go to a summary page in any form, it should have correct Welsh Translation for Mark as complete
- Go to a form that has build text field component, it should have correct Welsh translation for "Remove" text


### Screenshots of UI changes (if applicable)
Mark as complete:
<img width="1243" alt="Screenshot 2024-10-15 at 12 13 35" src="https://github.com/user-attachments/assets/a5b8b83c-ea6c-421b-9403-e6a09763abfa">

Remove:
<img width="1106" alt="Screenshot 2024-10-15 at 12 14 03" src="https://github.com/user-attachments/assets/7e1ed29b-3b39-4a97-b578-1dbc37f420ed">
