### PR TITLE
Translation changes for following jira tickets [FS-4499/FS-4500/FS-4505/FS-4507/FS-4510]

### DIFF
--- a/fsd_config/form_jsons/cof/cy/gwybodaeth-am-y-sefydliad-cof.json
+++ b/fsd_config/form_jsons/cof/cy/gwybodaeth-am-y-sefydliad-cof.json
@@ -370,7 +370,7 @@
             "classes": "govuk-!-width-two-thirds"
           },
           "type": "NumberField",
-          "title": "Charity number ",
+          "title": "Rhif elusen ",
           "schema": {}
         }
       ],

--- a/fsd_config/form_jsons/cof/cy/gwybodaeth-am-yr-ased-cof.json
+++ b/fsd_config/form_jsons/cof/cy/gwybodaeth-am-yr-ased-cof.json
@@ -625,7 +625,7 @@
         },
         {
           "text": "Eisoes wedi'i llogi gan eich sefydliad",
-          "value": "Eisoes wedi'i llogi gan eich sefydliad"
+          "value": "Eisoes-wedi-i-llogi-gan-eich-sefydliad"
         }
       ]
     },
@@ -986,10 +986,10 @@
       }
     },
     {
-      "displayName": "Eisoes wedi'i llogi gan eich sefydliad - Ie",
+      "displayName": "Eisoes-wedi-i-llogi-gan-eich-sefydliad-Ie",
       "name": "hWsHyx",
       "value": {
-        "name": "Eisoes wedi'i llogi gan eich sefydliad - Ie",
+        "name": "Eisoes-wedi-i-llogi-gan-eich-sefydliad-Ie",
         "conditions": [
           {
             "field": {
@@ -1000,8 +1000,8 @@
             "operator": "is",
             "value": {
               "type": "Value",
-              "value": "Eisoes wedii llogi gan eich sefydliad",
-              "display": "Eisoes wedi'i llogi gan eich sefydliad"
+              "value": "Eisoes-wedi-i-llogi-gan-eich-sefydliad",
+              "display": "Eisoes-wedi-i-llogi-gan-eich-sefydliad"
             }
           }
         ]

--- a/runner/locales/cy.json
+++ b/runner/locales/cy.json
@@ -4,61 +4,86 @@
   "markAsComplete": "A ydych chi eisiau marcio bod yr adran hon wedi'i chwblhau?",
   "removeText": "Dileu",
   "validation": {
-    "required": "{#label} is required",
-    "max": "{#label} must be {#limit} characters or less",
-    "min": "{#label} must be {#limit} characters or more",
-    "regex": "enter a valid {#label}",
-    "email": "{#label} must be a valid email address",
-    "number": "{#label} must be a number",
-    "numberMin": "{#label} must be {#limit} or higher",
-    "numberMax": "{#label} must be {#limit} or lower",
-    "format": "Enter a valid {#label}",
-    "maxWords": "{#label} must be {#limit} words or fewer",
-    "dateRequired": "{#label} must be a real date",
-    "dateFormat": "{#label} must be a real date",
-    "dateMin": "{#label} must be the same as or after {#limit}",
-    "dateMax": "{#label} must be the same as or before {#limit}",
-    "selectRequired": "{#label} is required",
-    "title1": "There is a problem",
+    "required": "(cy) {#label} is required",
+    "max": "(cy) {#label} must be {#limit} characters or less",
+    "min": "(cy) {#label} must be {#limit} characters or more",
+    "regex": "(cy) enter a valid {#label}",
+    "email": "(cy) {#label} must be a valid email address",
+    "number": "(cy) {#label} must be a number",
+    "numberMin": "(cy) {#label} must be {#limit} or higher",
+    "numberMax": "(cy) {#label} must be {#limit} or lower",
+    "format": "(cy) Enter a valid {#label}",
+    "maxWords": "(cy) {#label} must be {#limit} words or fewer",
+    "dateRequired": "(cy) {#label} must be a real date",
+    "dateFormat": "(cy) {#label} must be a real date",
+    "dateMin": "(cy) {#label} must be the same as or after {#limit}",
+    "dateMax": "(cy) {#label} must be the same as or before {#limit}",
+    "selectRequired": "(cy) {#label} is required",
+    "title1": "(cy) There is a problem",
+    "title2": "(cy) Fix the following errors",
     "fileUpload": {
-      "filePartiallyUploadError": "The files have not fully uploaded",
-      "fileUploadSizeError": "File must be under ",
-      "fileUploadCombinedSizeError": "Combined filesize must be under ",
-      "fileUploadTypeError": "You can't upload files of this type.",
-      "fileUploadCountSingleError": "You can only upload a single file",
-      "fileUploadCountMaxError": "You can only upload {maxFiles} files",
-      "fileUploadCountMinError": "{labelText} requires {minimumRequiredFiles} files"
+      "filePartiallyUploadError": "(cy) The files have not fully uploaded",
+      "fileUploadSizeError": "(cy) File must be under ",
+      "fileUploadCombinedSizeError": "(cy) Combined filesize must be under ",
+      "fileUploadTypeError": "(cy) You can't upload files of this type.",
+      "fileUploadCountSingleError": "(cy) You can only upload a single file",
+      "fileUploadCountMaxError": "(cy) You can only upload {maxFiles} files",
+      "fileUploadCountMinError": "(cy) {labelText} requires {minimumRequiredFiles} files",
+      "fileUploadSelectedFileMaxError": "(cy) The selected file must be smaller than {size}MB"
+    },
+    "ukAddressField": {
+      "invalidPostCodeError": "(cy) Enter a valid postcode"
+    },
+    "telephoneNumberField": {
+      "incorrectFormat": "(cy) Enter a telephone number in the correct format"
     }
   },
   "components": {
     "clientSideFileUpload": {
-      "javascriptEnableMessageTitle": "You need to have JavaScript enabled to see your selected files",
-      "description1": "Why is JavaScript required?",
-      "description2": "Without JavaScript, you will be able to select files to upload, but you won't be able to see them on this page.",
-      "description3": "Your files will still be uploaded when you hit \"Save and continue\". If you revisit this page, you will be able to see your previously uploaded files.",
-      "fileUploadBtn": "Choose file",
-      "filesUploadBtn": "Choose files",
+      "javascriptEnableMessageTitle": "(cy) You need to have JavaScript enabled to see your selected files",
+      "description1": "(cy) Why is JavaScript required?",
+      "description2": "(cy) Without JavaScript, you will be able to select files to upload, but you won't be able to see them on this page.",
+      "description3": "(cy) Your files will still be uploaded when you hit \"Save and continue\". If you revisit this page, you will be able to see your previously uploaded files.",
+      "fileUploadBtn": "(cy) Choose file",
+      "filesUploadBtn": "(cy) Choose files",
       "table": {
         "fileNameCol": "Enw'r ffeil",
         "fileSizeCol": "Maint y ffeil",
         "fileProgressCol": "Cynnydd",
         "fileActionCol": "Gweithredu",
         "fileActionComplete": "Cyflawn",
-        "fileActionFailed": "Failed",
-        "deleteBtn": "Delete"
+        "fileActionFailed": "(cy) Failed",
+        "deleteBtn": "(cy) Delete"
       }
     },
     "freeTextField": {
       "wordCountReminder": "Mae gennych {count} o eiriau'n weddill",
-      "wordCountRemainingError": "You have {count} words too many",
-      "wordCountError": "You can enter up to {count} words",
-      "error": "Error:"
+      "wordCountRemainingError": "(cy) You have {count} words too many",
+      "wordCountError": "(cy) You can enter up to {count} words",
+      "error": "(cy) Error:"
+    },
+    "markAsComplete": {
+      "error": "(cy) You must select yes or no"
+    },
+    "declaration": {
+      "error": "(cy) You must declare to be able to submit this application"
+    },
+    "ukAddressField": {
+      "addressLine1": "Llinell cyfeiriad 1",
+      "addressLine2": "Llinell cyfeiriad 2",
+      "townOrCity": "Tref neu ddinas",
+      "county": "Sir",
+      "postcode": "Cod post"
+    },
+    "yesOrNoField": {
+      "yes": "(cy) Yes",
+      "no": "(cy) No"
     }
   },
   "head": {
     "banner": {
-      "title": "This is a new service.",
-      "tag": "beta"
+      "title": "(cy) This is a new service.",
+      "tag": "(cy) beta"
     }
   },
   "footer": {

--- a/runner/locales/en.json
+++ b/runner/locales/en.json
@@ -20,6 +20,7 @@
     "dateMax": "{#label} must be the same as or before {#limit}",
     "selectRequired": "{#label} is required",
     "title1": "There is a problem",
+    "title2": "Fix the following errors",
     "fileUpload": {
       "filePartiallyUploadError": "The files have not fully uploaded",
       "fileUploadSizeError": "File must be under ",
@@ -27,7 +28,14 @@
       "fileUploadTypeError": "You can't upload files of this type.",
       "fileUploadCountSingleError": "You can only upload a single file",
       "fileUploadCountMaxError": "You can only upload {maxFiles} files",
-      "fileUploadCountMinError": "{labelText} requires {minimumRequiredFiles} files"
+      "fileUploadCountMinError": "{labelText} requires {minimumRequiredFiles} files",
+      "fileUploadSelectedFileMaxError": "The selected file must be smaller than {size}MB"
+    },
+    "ukAddressField": {
+      "invalidPostCodeError": "Enter a valid postcode"
+    },
+    "telephoneNumberField": {
+      "incorrectFormat": "Enter a telephone number in the correct format"
     }
   },
   "components": {
@@ -53,6 +61,23 @@
       "wordCountRemainingError": "You have {count} words too many",
       "wordCountError": "You can enter up to {count} words",
       "error": "Error:"
+    },
+    "markAsComplete": {
+      "error": "You must select yes or no"
+    },
+    "declaration": {
+      "error": "You must declare to be able to submit this application"
+    },
+    "ukAddressField": {
+      "addressLine1": "Address line 1",
+      "addressLine2": "Address line 2",
+      "townOrCity": "Town or city",
+      "county": "County",
+      "postcode": "Postcode"
+    },
+    "yesOrNoField": {
+      "yes": "Yes",
+      "no": "No"
     }
   },
   "head": {

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -38,6 +38,7 @@ import clientSideUploadPlugin from "./plugins/ClientSideUploadPlugin";
 import {MockUploadService} from "./services/MockUploadService";
 import {catboxProvider} from "./services/AdapterCacheService";
 import LanguagePlugin from "./plugins/LanguagePlugin";
+import {TranslationLoaderService} from "./plugins/engine/service/TranslationLoaderService";
 
 const serverOptions = (): ServerOptions => {
     const hasCertificate = config.sslKey && config.sslCert;
@@ -130,7 +131,7 @@ async function createServer(routeConfig: RouteConfig) {
     await server.register(pluginAuth);
     await server.register(LanguagePlugin);
 
-    server.registerService([AdapterCacheService, NotifyService, PayService, WebhookService, AddressService]);
+    server.registerService([AdapterCacheService, NotifyService, PayService, WebhookService, AddressService, TranslationLoaderService]);
     if (config.isE2EModeEnabled && config.isE2EModeEnabled == "true") {
         console.log("E2E Mode enabled")
         server.registerService([Schmervice.withName("s3UploadService", MockUploadService),]);

--- a/runner/src/server/plugins/engine/MainPlugin.ts
+++ b/runner/src/server/plugins/engine/MainPlugin.ts
@@ -4,6 +4,9 @@ import {AdapterFormModel} from "./models";
 import {Options} from "./types/PluginOptions";
 import {HapiServer} from "../../types";
 import {RegisterFormPublishApi} from "./api";
+import fs from "fs";
+import Boom from "boom";
+
 
 configure([
     // Configure Nunjucks to allow rendering of content that is revealed conditionally.
@@ -26,10 +29,27 @@ export const plugin = {
         server.app.forms = {};
         // @ts-ignore
         const forms = server.app.forms;
+        let translationEn = undefined
+        let translationCy = undefined
+        try {
+            const filePathCy = path.join(__dirname, '../../../locales', `cy.json`);
+            const filePathEn = path.join(__dirname, '../../../locales', `en.json`);
+            // @ts-ignore
+            const dataCy = fs.readFileSync(filePathCy, 'utf8');
+            const dataEn = fs.readFileSync(filePathEn, 'utf8');
+            translationEn = JSON.parse(dataEn);
+            translationCy = JSON.parse(dataCy);
+        } catch (err) {
+            console.error(`Error reading translations`, err);
+            Boom.internal("Cannot read translations from the local folder")
+        }
+
         configs.forEach((config) => {
             forms[config.id] = new AdapterFormModel(config.configuration, {
                 ...modelOptions,
-                basePath: config.id
+                basePath: config.id,
+                translationEn: translationEn,
+                translationCy: translationCy
             });
         });
         options.forms = forms;

--- a/runner/src/server/plugins/engine/MainPlugin.ts
+++ b/runner/src/server/plugins/engine/MainPlugin.ts
@@ -4,8 +4,7 @@ import {AdapterFormModel} from "./models";
 import {Options} from "./types/PluginOptions";
 import {HapiServer} from "../../types";
 import {RegisterFormPublishApi} from "./api";
-import fs from "fs";
-import Boom from "boom";
+import {Localization} from "./service/TranslationLoaderService";
 
 
 configure([
@@ -23,35 +22,22 @@ export const plugin = {
     name: "@communitiesuk/runner/engine",
     dependencies: "@hapi/vision",
     multiple: true,
-    register: (server: HapiServer, options: Options) => {
+    register: async (server: HapiServer, options: Options) => {
         const {modelOptions, configs} = options;
+        const {translationLoaderService} = server.services([]);
         // @ts-ignore
         server.app.forms = {};
         // @ts-ignore
         const forms = server.app.forms;
 
-        // translations that needs for the component level
-        let translationEn = undefined
-        let translationCy = undefined
-        try {
-            const filePathCy = path.join(__dirname, '../../../locales', `cy.json`);
-            const filePathEn = path.join(__dirname, '../../../locales', `en.json`);
-            // @ts-ignore
-            const dataCy = fs.readFileSync(filePathCy, 'utf8');
-            const dataEn = fs.readFileSync(filePathEn, 'utf8');
-            translationEn = JSON.parse(dataEn);
-            translationCy = JSON.parse(dataCy);
-        } catch (err) {
-            console.error(`Error reading translations`, err);
-            Boom.internal("Cannot read translations from the local folder")
-        }
+        const translations: Localization = await translationLoaderService.getTranslations()
 
         configs.forEach((config) => {
             forms[config.id] = new AdapterFormModel(config.configuration, {
                 ...modelOptions,
                 basePath: config.id,
-                translationEn: translationEn,
-                translationCy: translationCy
+                translationEn: translations.en,
+                translationCy: translations.cy
             });
         });
         options.forms = forms;

--- a/runner/src/server/plugins/engine/MainPlugin.ts
+++ b/runner/src/server/plugins/engine/MainPlugin.ts
@@ -29,6 +29,8 @@ export const plugin = {
         server.app.forms = {};
         // @ts-ignore
         const forms = server.app.forms;
+
+        // translations that needs for the component level
         let translationEn = undefined
         let translationCy = undefined
         try {

--- a/runner/src/server/plugins/engine/api/RegisterFormPublishApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterFormPublishApi.ts
@@ -12,7 +12,8 @@ import {
 import {PluginSpecificConfiguration} from "@hapi/hapi";
 import {jwtAuthStrategyName} from "../Auth";
 import {config} from "../../utils/AdapterConfigurationSchema";
-
+import path from "path";
+import fs from "fs";
 
 export class RegisterFormPublishApi implements RegisterApi {
 
@@ -46,13 +47,31 @@ export class RegisterFormPublishApi implements RegisterApi {
                 const payload = request.payload as FormPayload;
                 const {id, configuration} = payload;
 
+                // translations that needs for the component level
+                let translationEn = undefined
+                let translationCy = undefined
+                try {
+                    const filePathCy = path.join(__dirname, '../../../../locales', `cy.json`);
+                    const filePathEn = path.join(__dirname, '../../../../locales', `en.json`);
+                    // @ts-ignore
+                    const dataCy = fs.readFileSync(filePathCy, 'utf8');
+                    const dataEn = fs.readFileSync(filePathEn, 'utf8');
+                    translationEn = JSON.parse(dataEn);
+                    translationCy = JSON.parse(dataCy);
+                } catch (err) {
+                    console.error(`Error reading translations`, err);
+                    Boom.internal("Cannot read translations from the local folder")
+                }
+
                 const parsedConfiguration =
                     typeof configuration === "string"
                         ? JSON.parse(configuration)
                         : configuration;
                 forms[id] = new AdapterFormModel(parsedConfiguration, {
                     ...modelOptions,
-                    basePath: id
+                    basePath: id,
+                    translationEn: translationEn,
+                    translationCy: translationCy
                 });
                 return h.response({}).code(204);
             }

--- a/runner/src/server/plugins/engine/components/AdapterTelephoneNumberField.ts
+++ b/runner/src/server/plugins/engine/components/AdapterTelephoneNumberField.ts
@@ -1,0 +1,55 @@
+import {TelephoneNumberField} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components";
+import {TelephoneNumberFieldComponent} from "@xgovformbuilder/model";
+import {AdapterFormModel} from "../models";
+// @ts-ignore
+import joi from "joi";
+import {
+    internationalPhoneValidator
+} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/helpers";
+
+const PATTERN = /^[0-9\\\s+()-]*$/;
+
+export class AdapterTelephoneNumberField extends TelephoneNumberField {
+
+    constructor(def: TelephoneNumberFieldComponent, model: AdapterFormModel) {
+        //@ts-ignore
+        super(def, model);
+        //@ts-ignore
+        let incorrectFormat = model.options.translationEn.validation.telephoneNumberField.incorrectFormat;
+        if (model.def.metadata?.isWelsh) {
+            //@ts-ignore
+            incorrectFormat = model.options.translationCy.validation.telephoneNumberField.incorrectFormat;
+        }
+        const {options = {}, schema = {}} = def;
+        const pattern = schema.regex ? new RegExp(schema.regex) : PATTERN;
+        let componentSchema = joi.string();
+
+        if (options.required === false) {
+            componentSchema = componentSchema.allow("").allow(null);
+        }
+        componentSchema = componentSchema
+            .pattern(pattern)
+            .message(incorrectFormat)
+            .label(def.title.toLowerCase());
+
+        if (schema.max) {
+            componentSchema = componentSchema.max(schema.max);
+        }
+
+        if (schema.min) {
+            componentSchema = componentSchema.min(schema.min);
+        }
+
+        if (options.isInternational) {
+            // @ts-ignore
+            componentSchema = componentSchema.custom(internationalPhoneValidator);
+        }
+
+        if (options.customValidationMessages) {
+            componentSchema = componentSchema.messages(
+                options.customValidationMessages
+            );
+        }
+        this.schema = componentSchema;
+    }
+}

--- a/runner/src/server/plugins/engine/components/AdapterYesNoField.ts
+++ b/runner/src/server/plugins/engine/components/AdapterYesNoField.ts
@@ -1,0 +1,17 @@
+import {YesNoField} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components";
+import {InputFieldsComponentsDef} from "@xgovformbuilder/model";
+import {AdapterFormModel} from "../models";
+
+
+export class AdapterYesNoField extends YesNoField {
+
+    constructor(def: InputFieldsComponentsDef, model: AdapterFormModel) {
+        super(def, model);
+        this.list.items[0].text = model.options.translationEn.components.yesOrNoField.yes;
+        this.list.items[1].text = model.options.translationEn.components.yesOrNoField.no;
+        if (model.def.metadata?.isWelsh) {
+            this.list.items[0].text = model.options.translationCy.components.yesOrNoField.yes;
+            this.list.items[1].text = model.options.translationCy.components.yesOrNoField.no;
+        }
+    }
+}

--- a/runner/src/server/plugins/engine/components/UkAddressField.ts
+++ b/runner/src/server/plugins/engine/components/UkAddressField.ts
@@ -38,7 +38,7 @@ export class UkAddressField extends AdapterFormComponent {
         const isRequired = !("required" in options && options.required === false);
 
         let addressLine1Title = model.options.translationEn.components.ukAddressField.addressLine1;
-        let addressLine2Title = model.options.translationEn.components.ukAddressField.addressLine1;
+        let addressLine2Title = model.options.translationEn.components.ukAddressField.addressLine2;
         let townCityText = model.options.translationEn.components.ukAddressField.townOrCity;
         let county = model.options.translationEn.components.ukAddressField.county;
         let postcode = model.options.translationEn.components.ukAddressField.postcode;
@@ -46,7 +46,7 @@ export class UkAddressField extends AdapterFormComponent {
 
         if (model.def.metadata?.isWelsh) {
             addressLine1Title = model.options.translationCy.components.ukAddressField.addressLine1;
-            addressLine2Title = model.options.translationCy.components.ukAddressField.addressLine1;
+            addressLine2Title = model.options.translationCy.components.ukAddressField.addressLine2;
             townCityText = model.options.translationCy.components.ukAddressField.townOrCity;
             county = model.options.translationCy.components.ukAddressField.county;
             postcode = model.options.translationCy.components.ukAddressField.postcode;

--- a/runner/src/server/plugins/engine/components/UkAddressField.ts
+++ b/runner/src/server/plugins/engine/components/UkAddressField.ts
@@ -37,18 +37,20 @@ export class UkAddressField extends AdapterFormComponent {
         const stateSchema = buildStateSchema("date", this);
         const isRequired = !("required" in options && options.required === false);
 
-        let addressLine1Title = "Address line 1";
-        let addressLine2Title = "Address line 2";
-        let townCityText = "Town or city";
-        let county = "County";
-        let postcode = "Postcode";
+        let addressLine1Title = model.options.translationEn.components.ukAddressField.addressLine1;
+        let addressLine2Title = model.options.translationEn.components.ukAddressField.addressLine1;
+        let townCityText = model.options.translationEn.components.ukAddressField.townOrCity;
+        let county = model.options.translationEn.components.ukAddressField.county;
+        let postcode = model.options.translationEn.components.ukAddressField.postcode;
+        let invalidPostCodeError = model.options.translationEn.validation.ukAddressField.invalidPostCodeError;
 
         if (model.def.metadata?.isWelsh) {
-            addressLine1Title = "Llinell cyfeiriad 1";
-            addressLine2Title = "Llinell cyfeiriad 2";
-            townCityText = "Tref neu ddinas";
-            county = "Sir";
-            postcode = "Cod post";
+            addressLine1Title = model.options.translationCy.components.ukAddressField.addressLine1;
+            addressLine2Title = model.options.translationCy.components.ukAddressField.addressLine1;
+            townCityText = model.options.translationCy.components.ukAddressField.townOrCity;
+            county = model.options.translationCy.components.ukAddressField.county;
+            postcode = model.options.translationCy.components.ukAddressField.postcode;
+            invalidPostCodeError = model.options.translationCy.validation.ukAddressField.invalidPostCodeError;
         }
 
         const childrenList: any = [
@@ -100,8 +102,8 @@ export class UkAddressField extends AdapterFormComponent {
                 options: {
                     required: isRequired,
                     customValidationMessages: {
-                        "string.max": "Enter a valid postcode",
-                        "string.pattern.base": "Enter a valid postcode",
+                        "string.max": invalidPostCodeError,
+                        "string.pattern.base": invalidPostCodeError,
                     },
                     classes: "govuk-!-width-one-half",
                     optionalText: false,

--- a/runner/src/server/plugins/engine/components/index.ts
+++ b/runner/src/server/plugins/engine/components/index.ts
@@ -50,16 +50,16 @@ export {
     SelectField
 } from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/SelectField";
 export {
-    TelephoneNumberField
-} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/TelephoneNumberField";
+    AdapterTelephoneNumberField as TelephoneNumberField
+} from "./AdapterTelephoneNumberField";
 export {TextField} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/TextField";
 export {TimeField} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/TimeField";
 export {
     WebsiteField
 } from "./WebsiteField";
 export {
-    YesNoField
-} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/YesNoField";
+    AdapterYesNoField as YesNoField
+} from "./AdapterYesNoField";
 export {
     MonthYearField
 } from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/MonthYearField";

--- a/runner/src/server/plugins/engine/models/AdapterFormModel.ts
+++ b/runner/src/server/plugins/engine/models/AdapterFormModel.ts
@@ -54,6 +54,8 @@ export class AdapterFormModel {
 
     feeOptions: AdapterFormDefinition["feeOptions"];
     specialPages: AdapterFormDefinition["specialPages"];
+    translationEn: any;
+    translationCy: any;
 
     constructor(def, options) {
         //@ts-ignore
@@ -107,6 +109,11 @@ export class AdapterFormModel {
         this.startPage = this.pages.find((page) => page.path === def.startPage);
         this.specialPages = def.specialPages;
         this.feeOptions = {...DEFAULT_FEE_OPTIONS, ...def.feeOptions};
+
+        if (options && options.translationEn && options.translationCy) {
+            this.translationEn = options.translationEn;
+            this.translationCy = options.translationCy;
+        }
     }
 
     /**

--- a/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
@@ -414,7 +414,7 @@ export class PageControllerBase {
             });
 
             return {
-                titleText: request.i18n.__('validation.title1'),
+                titleText: request.i18n.__('validation.title2'),
                 errorList: errorList.filter(
                     ({text}, index) =>
                         index === errorList.findIndex((err) => err.text === text)
@@ -798,7 +798,7 @@ export class PageControllerBase {
             });
 
             formResult.errors = Object.is(formResult.errors, null)
-                ? {titleText: request.i18n.__('validation.title1'),}
+                ? {titleText: request.i18n.__('validation.title2'),}
                 : formResult.errors;
             formResult.errors.errorList = reformattedErrors;
         }

--- a/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
@@ -389,7 +389,7 @@ export class PageControllerBase {
      * Parses the errors from joi.validate so they can be rendered by govuk-frontend templates
      * @param validationResult - provided by joi.validate
      */
-    getErrors(validationResult): FormSubmissionErrors | undefined {
+    getErrors(validationResult, request: HapiRequest): FormSubmissionErrors | undefined {
         if (validationResult && validationResult.error) {
             const isoRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
 
@@ -414,7 +414,7 @@ export class PageControllerBase {
             });
 
             return {
-                titleText: this.errorSummaryTitle,
+                titleText: request.i18n.__('validation.title1'),
                 errorList: errorList.filter(
                     ({text}, index) =>
                         index === errorList.findIndex((err) => err.text === text)
@@ -433,7 +433,7 @@ export class PageControllerBase {
      */
     validate(value, schema, request: HapiRequest) {
         const result = schema.validate(value, validationOptions(request));
-        const errors = result.error ? this.getErrors(result) : null;
+        const errors = result.error ? this.getErrors(result, request) : null;
 
         return {value: result.value, errors};
     }
@@ -697,7 +697,7 @@ export class PageControllerBase {
         const progress = state.progress || [];
         const {num} = request.query;
 
-        this.validatingForErrors(hasFilesizeError, fileFields, formResult, preHandlerErrors);
+        this.validatingForErrors(hasFilesizeError, fileFields, formResult, preHandlerErrors, request);
 
         const additionalValidationErrors = await this.validateComponentFunctions(request, viewModel);
         if (additionalValidationErrors.length > 0) {
@@ -759,19 +759,19 @@ export class PageControllerBase {
         await adapterCacheService.mergeState(request, update, nullOverride, arrayMerge);
     }
 
-    private validatingForErrors(hasFilesizeError: boolean, fileFields, formResult: any, preHandlerErrors) {
+    private validatingForErrors(hasFilesizeError: boolean, fileFields, formResult: any, preHandlerErrors, request: HapiRequest) {
         if (hasFilesizeError) {
             const reformattedErrors = fileFields.map((field) => {
                 return {
                     path: field.name,
                     href: `#${field.name}`,
                     name: field.name,
-                    text: `The selected file must be smaller than ${config.maxFileSizeStringInMb}MB`,
+                    text: request.i18n.__('validation.fileUpload.fileUploadSelectedFileMaxError').replace("{size}", config.maxFileSizeStringInMb),
                 };
             });
 
             formResult.errors = Object.is(formResult.errors, null)
-                ? {titleText: "Fix the following errors"}
+                ? {titleText: request.i18n.__('validation.title2'),}
                 : formResult.errors;
             formResult.errors.errorList = reformattedErrors;
         }
@@ -798,7 +798,7 @@ export class PageControllerBase {
             });
 
             formResult.errors = Object.is(formResult.errors, null)
-                ? {titleText: "Fix the following errors"}
+                ? {titleText: request.i18n.__('validation.title1'),}
                 : formResult.errors;
             formResult.errors.errorList = reformattedErrors;
         }
@@ -908,10 +908,6 @@ export class PageControllerBase {
 
     get conditionOptions() {
         return this.model.conditionOptions;
-    }
-
-    get errorSummaryTitle() {
-        return "Fix the following errors";
     }
 
     /**

--- a/runner/src/server/plugins/engine/page-controllers/PlaybackUploadPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PlaybackUploadPageController.ts
@@ -90,7 +90,7 @@ export class PlaybackUploadPageController extends PageController {
             const {payload} = request;
             const result = this.formSchema.validate(payload, validationOptions(request));
             if (result.error) {
-                const errors = this.getErrors(result);
+                const errors = this.getErrors(result, request);
                 let sectionTitle = this.section?.title;
                 return h.view("upload-playback", {
                     sectionTitle: sectionTitle,

--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -207,8 +207,7 @@ export class SummaryPageController extends PageController {
                 const {declaration} = request.payload as { declaration?: any; };
 
                 if (!declaration) {
-                    request.yar.flash("declarationError",
-                        "You must declare to be able to submit this application");
+                    request.yar.flash("declarationError", request.i18n.__('components.declaration.error'));
                     const url = request.headers.referer ?? request.path;
                     return redirectTo(request, h, `${url}#declaration`);
                 }
@@ -219,7 +218,7 @@ export class SummaryPageController extends PageController {
             if (summaryViewModel.markAsCompleteComponent) {
                 const {markAsComplete} = request.payload as { markAsComplete?: any };
                 if (!markAsComplete) {
-                    request.yar.flash("markAsCompleteError", "You must select yes or no");
+                    request.yar.flash("markAsCompleteError", request.i18n.__('components.markAsComplete.error'));
                     return redirectTo(request, h, `${request.headers.referer}#markAsComplete`);
                 }
                 summaryViewModel.addMarkAsCompleteAsQuestion(

--- a/runner/src/server/plugins/engine/service/TranslationLoaderService.ts
+++ b/runner/src/server/plugins/engine/service/TranslationLoaderService.ts
@@ -1,0 +1,33 @@
+import Boom from "boom";
+import fs from "fs";
+import path from "path";
+
+export type Localization = {
+    en: any
+    cy: any
+}
+
+export class TranslationLoaderService {
+    async getTranslations() {
+        // translations that need for the component level will be loaded from this service
+        let translationEn = undefined
+        let translationCy = undefined
+        try {
+            const filePathCy = path.join(__dirname, '../../../../locales', `cy.json`);
+            const filePathEn = path.join(__dirname, '../../../../locales', `en.json`);
+            // @ts-ignore
+            const dataCy = await fs.readFileSync(filePathCy, 'utf8');
+            const dataEn = await fs.readFileSync(filePathEn, 'utf8');
+            translationEn = JSON.parse(dataEn);
+            translationCy = JSON.parse(dataCy);
+            const translations: Localization = {
+                en: translationEn,
+                cy: translationCy,
+            }
+            return translations;
+        } catch (err) {
+            console.error(`Error reading translations`, err);
+            throw Boom.internal("Cannot read translations from the local folder")
+        }
+    }
+}

--- a/runner/src/server/types.ts
+++ b/runner/src/server/types.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../digital-form-builder/runner/src/server/services";
 import {AdapterCacheService, S3UploadService} from "./services";
 import {AdapterStatusService} from "./services";
+import {TranslationLoaderService} from "./plugins/engine/service/TranslationLoaderService";
 
 export type Services = (services: string[]) => {
     adapterCacheService: AdapterCacheService;
@@ -24,6 +25,7 @@ export type Services = (services: string[]) => {
     s3UploadService: S3UploadService;
     webhookService: WebhookService;
     adapterStatusService: AdapterStatusService;
+    translationLoaderService: TranslationLoaderService;
 };
 
 export type RouteConfig = {


### PR DESCRIPTION
Adding CY and EN translations for the following parts, also it contains error messages for each validations

1. Telephone number field
2. Uk address field
3. Yes or no field
4. Some of the common error messages

For non-translated CY will have `(cy)` tag in as a prefix for identification purpose before the fund rounds open planning to remove them or replace with actual translations

1. https://mhclgdigital.atlassian.net/browse/FS-4499
2. https://mhclgdigital.atlassian.net/browse/FS-4500
3. https://mhclgdigital.atlassian.net/browse/FS-4505
4. https://mhclgdigital.atlassian.net/browse/FS-4507
5. https://mhclgdigital.atlassian.net/browse/FS-4510
