### PR TITLE
ignore some sections from the summary page

### DIFF
--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -67,5 +67,6 @@
   "migrationBannerEnabled": {
     "__name": "MIGRATION_BANNER_ENABLED",
     "__format": "boolean"
-  }
+  },
+  "ignoreSectionsFromSummary": "IGNORE_SECTIONS_FROM_SUMMARY_PAGE"
 }

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -108,4 +108,5 @@ module.exports = {
   awsRegion: "eu-west-2", // The aws buckets region
   migrationBannerEnabled: false,
   eligibilityResultUrl: "",
+  ignoreSectionsFromSummary: ["FabDefault"],
 };

--- a/runner/src/server/plugins/engine/models/ViewModelBase.ts
+++ b/runner/src/server/plugins/engine/models/ViewModelBase.ts
@@ -264,7 +264,7 @@ export class ViewModelBase {
                     });
                 }
             } else {
-                if (section?.name && section?.title) {
+                if ((section?.name && section?.title) && !config.ignoreSectionsFromSummary.includes(section?.name)) {
                     details.push({
                         name: section?.name,
                         title: section?.title,


### PR DESCRIPTION
When there are default type of sections and user need to ignore showing the sections that was not answered will be able to use this feature and ignoreSectionsFromSummary is a array of section names that need to give to ignore in the summary page