### PR TITLE
Fixing logic in welsh forms

### DIFF
--- a/fsd_config/form_jsons/cof25/cy/costau-gweithredol-cof-25.json
+++ b/fsd_config/form_jsons/cof25/cy/costau-gweithredol-cof-25.json
@@ -45,9 +45,6 @@
       ],
       "next": [
         {
-          "path": "/incwm-i-redeg-yr-ased"
-        },
-        {
           "path": "/summary"
         }
       ],

--- a/fsd_config/form_jsons/cof25/cy/gwybodaeth-am-yr-ased-cof-25.json
+++ b/fsd_config/form_jsons/cof25/cy/gwybodaeth-am-yr-ased-cof-25.json
@@ -296,10 +296,6 @@
           "condition": "EQpfAl"
         },
         {
-          "path": "/trosiad-aseth-cymunedol",
-          "condition": "rrSKPO"
-        },
-        {
           "path": "/asedau-o-werth-cymunedol"
         }
       ],
@@ -978,7 +974,7 @@
             "operator": "is",
             "value": {
               "type": "Value",
-              "value": "Eisoes yn eiddo iw sefydliad",
+              "value": "Eisoes yn eiddo i'w sefydliad",
               "display": "Eisoes yn eiddo i'w sefydliad"
             }
           }
@@ -1022,8 +1018,8 @@
             "operator": "contains",
             "value": {
               "type": "Value",
-              "value": "Llogir eiddo",
-              "display": "Llogi'r eiddo"
+              "value": "Wedî'i restru ar gyfer gwaredu",
+              "display": "Wedî'i restru ar gyfer gwaredu"
             }
           }
         ]


### PR DESCRIPTION
During generation of the all questions page for COF25, the script was failing. The script is more strict on following paths and conditions than the runner (also the runner doesn't evaluate the full path with conditions until you hit individual pages, whereas the script does it all in one go).

On investigation I have corrected the following items.
fsd_config/form_jsons/cof25/cy/costau-gweithredol-cof-25.json
- Remove the next path `"/incwm-i-redeg-yr-ased"` as this page does not exist in that form

fsd_config/form_jsons/cof25/cy/gwybodaeth-am-yr-ased-cof-25.json
- Line 981, added a missing `'` because the value in the condition did not match the value in the list
- Line 1025 - changed this value. The question translates as 'why is the asset at risk of closure'. The same condition (`EQpfAl`) in the english form has the value 'Listed for disposal'. The welsh form for this condition had the value 'Llogir eiddo` which translates as 'Property is rented'. That value does not exist in the list `YNTnCC`. Value updated to the welsh equivalent of 'listed for disposal', which according to the list we already had in this form is "Wedî'i restru ar gyfer gwaredu"
