### PR TITLE
FS-4742 multi input field addressfield fix in runner and allow multi line textfield and enhancements in designer on multi input field

### DIFF
--- a/designer/client/components/Page/AdapterPage.tsx
+++ b/designer/client/components/Page/AdapterPage.tsx
@@ -64,6 +64,7 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
                     delete component.pageOptions
                 })
                 page.controller = "RepeatingFieldPageController"
+                save(data)
             }
 
             //@ts-ignore
@@ -84,6 +85,7 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
                         samePageTitle: page.options.customText.samePageTitle ? page.options.customText.samePageTitle : "",
                     }
                 }
+                save(data)
             }
         })
         if (multiInputPages.length <= 0) {
@@ -95,6 +97,7 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
                     delete page.options.summaryDisplayMode;
                     // @ts-ignore
                     delete page.options.customText;
+                    save(data)
                 }
             })
         }

--- a/designer/client/components/Page/AdapterPage.tsx
+++ b/designer/client/components/Page/AdapterPage.tsx
@@ -44,6 +44,7 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
     const {data, save} = useContext(AdapterDataContext);
     const [isEditingPage, setIsEditingPage] = useState(false);
     const [isCreatingComponent, setIsCreatingComponent] = useState(false);
+    let isMultiInputUpdated: boolean = false;
 
     if (data.pages) {
         const multiInputPages = data.pages.filter(page =>
@@ -51,6 +52,7 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
             page.components.some(component => component.type === 'MultiInputField')
         );
         multiInputPages.forEach(page => {
+            isMultiInputUpdated = true;
             // @ts-ignore
             const multiInputFields = page.components.filter(component => component.type === 'MultiInputField');
             //@ts-ignore
@@ -64,7 +66,6 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
                     delete component.pageOptions
                 })
                 page.controller = "RepeatingFieldPageController"
-                save(data)
             }
 
             //@ts-ignore
@@ -85,22 +86,29 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
                         samePageTitle: page.options.customText.samePageTitle ? page.options.customText.samePageTitle : "",
                     }
                 }
-                save(data)
             }
         })
         if (multiInputPages.length <= 0) {
             data.pages.forEach(page => {
                 if (page.controller === "RepeatingFieldPageController") {
+                    isMultiInputUpdated = true;
                     // @ts-ignore
                     delete page.controller;
                     // @ts-ignore
                     delete page.options.summaryDisplayMode;
                     // @ts-ignore
                     delete page.options.customText;
-                    save(data)
                 }
             })
         }
+    }
+
+    const publishAndDirectToPreview = async (_e) => {
+        _e.preventDefault();
+        if (isMultiInputUpdated) {
+            await save(data);
+        }
+        window.location.href = new URL(`${id}${page.path}`, previewUrl).toString();
     }
 
     const onSortEnd = ({oldIndex, newIndex}) => {
@@ -167,7 +175,7 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
                 </button>
                 <a
                     title={i18n("Preview page")}
-                    href={new URL(`${id}${page.path}`, previewUrl).toString()}
+                    onClick={(_e) => publishAndDirectToPreview(_e)}
                     target="_blank"
                     rel="noreferrer"
                 >

--- a/designer/client/components/multiinput-field-edit/MultiInputFieldEdit.tsx
+++ b/designer/client/components/multiinput-field-edit/MultiInputFieldEdit.tsx
@@ -49,6 +49,10 @@ export const MultiInputFieldEdit: any = ({context = AdapterComponentContext}) =>
     const {selectedComponent} = state;
     //@ts-ignore
     const {options = {}} = selectedComponent;
+    //@ts-ignore
+    options.required = true
+    //@ts-ignore
+    selectedComponent.schema = {}
     const [pageOptions, setPageOptions] = useState({
         // @ts-ignore
         summaryDisplayMode: {
@@ -858,6 +862,7 @@ export const MultiInputFieldEdit: any = ({context = AdapterComponentContext}) =>
                         onChange={handleSubComponentSelection}>
                     <option value={"Clear"}>Please select</option>
                     <option value={"TextField"}>Text Field</option>
+                    <option value={"MultilineTextField"}>Multiline Text Field</option>
                     <option value={"NumberField"}>Number Field</option>
                     <option value={"RadiosField"}>Radios Field</option>
                     <option value={"DatePartsField"}>Date Parts Field</option>

--- a/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
+++ b/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
@@ -30,26 +30,29 @@ Feature: Multi Input Field Edit
     * I add table title name "Websitefield"
     * I add table title name "YesorNofield"
     * I add table title name "MonthYearfield"
+    * I add table title name "MultilineTextField"
     * I add table title "This is a table title"
     And I add child components
-      | component      | title                   | options                                             | additional | listItem     | name           |
-      | TextField      | This is a text field    | {"min": "1", "max": "5", "words":"2", "length":"2"} | true       |              | textfield      |
-      | NumberField    | This is a number field  | {"min": "1", "prefix": "£", "max":"2"}              | true       |              | numberfield    |
-      | RadiosField    | This is a radios field  | {}                                                  | false      | Types of egg | radiofield     |
-      | DatePartsField | This is a date field    | {"maxDaysInPast": "1", "maxDaysInFuture": "5"}      | true       |              | datepartsfield |
-      | WebsiteField   | This is a website field | {}                                                  | false      |              | websitefield   |
-      | YesNoField     | This is a yes no field  | {}                                                  | false      |              | yesnofield     |
-      | MonthYearField | This is a month field   | {}                                                  | false      |              | monthfield     |
-      | UkAddressField | This is a address field | {}                                                  | false      |              | addressfield   |
+      | component          | title                     | options                                             | additional | listItem     | name           |
+      | TextField          | This is a text field      | {"min": "1", "max": "5", "words":"2", "length":"2"} | true       |              | textfield      |
+      | NumberField        | This is a number field    | {"min": "1", "prefix": "£", "max":"2"}              | true       |              | numberfield    |
+      | RadiosField        | This is a radios field    | {}                                                  | false      | Types of egg | radiofield     |
+      | DatePartsField     | This is a date field      | {"maxDaysInPast": "1", "maxDaysInFuture": "5"}      | true       |              | datepartsfield |
+      | WebsiteField       | This is a website field   | {}                                                  | false      |              | websitefield   |
+      | YesNoField         | This is a yes no field    | {}                                                  | false      |              | yesnofield     |
+      | MonthYearField     | This is a month field     | {}                                                  | false      |              | monthfield     |
+      | UkAddressField     | This is a address field   | {}                                                  | false      |              | addressfield   |
+      | MultilineTextField | This is a multiline field | {}                                                  | false      |              | multilinefield |
     And I save component
     And I preview the page "First page"
     Then I see following components in the page
-      | component      | title                   |
-      | TextField      | This is a text field    |
-      | NumberField    | This is a number field  |
-      | RadiosField    | This is a radios field  |
-      | DatePartsField | This is a date field    |
-      | WebsiteField   | This is a website field |
-      | YesNoField     | This is a yes no field  |
-      | MonthYearField | This is a month field   |
-      | UkAddressField | This is a address field |
+      | component          | title                     |
+      | TextField          | This is a text field      |
+      | NumberField        | This is a number field    |
+      | RadiosField        | This is a radios field    |
+      | DatePartsField     | This is a date field      |
+      | WebsiteField       | This is a website field   |
+      | YesNoField         | This is a yes no field    |
+      | MonthYearField     | This is a month field     |
+      | UkAddressField     | This is a address field   |
+      | MultilineTextField | This is a multiline field |

--- a/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
+++ b/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
@@ -44,7 +44,7 @@ Feature: Multi Input Field Edit
       | UkAddressField     | This is a address field   | {}                                                  | false      |              | addressfield   |
       | MultilineTextField | This is a multiline field | {}                                                  | false      |              | multilinefield |
     And I save component
-    And I preview the page "First page"
+    And I preview the page "First page" without href
     Then I see following components in the page
       | component          | title                     |
       | TextField          | This is a text field      |

--- a/e2e-test/cypress/e2e/formPages.feature
+++ b/e2e-test/cypress/e2e/formPages.feature
@@ -11,19 +11,19 @@ Feature: Form pages
   Scenario: Edit a page title
     When I edit the page "First page"
     And I change the page title to "Testing"
-    * I preview the page "Testing"
+    * I preview the page "Testing" without href
     Then I see the heading "Testing"
 
   Scenario: Edit the page path
     When I edit the page "First page"
     And I change the page path to "my-first-test-page"
-    * I preview the page "First page"
+    * I preview the page "First page" without href
     Then I see the path is "/my-first-test-page"
 
   Scenario: Create a section from Edit page
     And I edit the page "First page"
     When I create a section titled "Personal Details"
-    And I preview the page "First page"
+    And I preview the page "First page" without href
     Then I see the section title "Personal Details" is displayed in the preview
 
   Scenario: Add a page

--- a/e2e-test/cypress/e2e/listComponents.feature
+++ b/e2e-test/cypress/e2e/listComponents.feature
@@ -25,7 +25,8 @@ Feature: List components
     When I create a component
       | page       | component   | title                   | list         |
       | First page | <component> | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see the options with hints
       | text          | hint                   |
       | sunny-side up | fried but not flipped  |
@@ -42,7 +43,8 @@ Feature: List components
     When I create a component
       | page       | component | title                   | list         |
       | First page | Select    | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see the dropdown options
       | labelText  | options                               |
       | First page | sunny-side up,over-easy,scrambled,raw |
@@ -51,7 +53,8 @@ Feature: List components
     When I create a component
       | page       | component    | title                   | list         |
       | First page | Autocomplete | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see the typeahead options
       | labelText  | options                               |
       | First page | sunny-side up,over-easy,scrambled,raw |
@@ -63,7 +66,8 @@ Feature: List components
     And I create a component
       | page       | component | title |
       | First page | Text      | Other |
-    * I preview the page "First page"
+    And I close the flyout
+    * I preview the page "First page" without href
     Then I see the heading "First page"
     * I see "Which eggs do you like?"
     * I see the field "Other"
@@ -72,7 +76,8 @@ Feature: List components
     When I create a component
       | page       | component | title                   | list         |
       | First page | Radios    | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see the options with hints
       | text          | hint                   |
       | sunny-side up | fried but not flipped  |
@@ -83,7 +88,8 @@ Feature: List components
     And I open the link "Types of egg"
     And I delete the list item "scrambled"
     * I save the list
-    * I preview the page "First page"
+    And I close the flyout
+    * I preview the page "First page" without href
     Then I don't see "scrambled"
 
 
@@ -91,7 +97,8 @@ Feature: List components
     When I create a component
       | page       | component | title                   | list         |
       | First page | Radios    | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see the options with hints
       | text          | hint                   |
       | sunny-side up | fried but not flipped  |
@@ -104,14 +111,16 @@ Feature: List components
       | initialItem | text | help                    | value |
       | scrambled   |      | eggs whisked with cream |       |
     * I save the list
-    * I preview the page "First page"
+    And I close the flyout
+    * I preview the page "First page" without href
     Then I see "eggs whisked with cream"
 
   Scenario: Content lists render
     When I create a component
       | page       | component | title                   | list         |
       | First page | List      | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see
       | text          |
       | sunny-side up |
@@ -123,7 +132,8 @@ Feature: List components
     When I create a component
       | page       | component  | title                   | list         |
       | First page | Flash card | Which eggs do you like? | Types of egg |
-    And I preview the page "First page"
+    And I close the flyout
+    And I preview the page "First page" without href
     Then I see
       | text          | hint                   |
       | sunny-side up | fried but not flipped  |

--- a/e2e-test/cypress/support/step_definitions/runner/i_preview_the_page_string_without_href.js
+++ b/e2e-test/cypress/support/step_definitions/runner/i_preview_the_page_string_without_href.js
@@ -1,0 +1,9 @@
+import { When } from "@badeball/cypress-cucumber-preprocessor";
+
+When("I preview the page {string} without href", (pageName) => {
+  cy.findByText(pageName, { ignore: ".govuk-visually-hidden" })
+    .closest(".page")
+    .within(() => {
+      cy.get(`a[title="Preview page"]`).click()
+    });
+});

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -217,6 +217,7 @@ export class RepeatingFieldPageController extends PageController {
                 rows,
             };
         }
+        console.log(rows);
     }
 
     async removeAtIndex(request, h) {

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -217,7 +217,6 @@ export class RepeatingFieldPageController extends PageController {
                 rows,
             };
         }
-        console.log(rows);
     }
 
     async removeAtIndex(request, h) {

--- a/runner/src/server/plugins/engine/views/components/multiinputfield.html
+++ b/runner/src/server/plugins/engine/views/components/multiinputfield.html
@@ -13,7 +13,7 @@
     <label class="govuk-label" for={{item.id}}>
         {% if item.componentType == "TextField"%}
         {{ govukInput(item) }}
-        {% elif item.componentType == "UkAddressField"%}
+        {% elif item.componentType == "MultilineTextField"%}
             {% if item.isCharacterOrWordCount %}
                 {{ govukCharacterCount(item) }}
             {% else %}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FS-4742

### Change description
Updated multiinputfield.html to correctly represent UK address fields, ensuring accurate formatting. Enhance the designer to properly sync controller-level changes with the runner. Additionally, introduced a multiline input component within the multi-input field to support multiline text inputs as required.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/502b2a80-4a41-4fb3-b971-abb08d18466f)
