### PR TITLE
FS-4777: adding fab default section while creating the pages, and this will automatically add into each page if a section is not available

### DIFF
--- a/designer/client/components/Page/AdapterPage.tsx
+++ b/designer/client/components/Page/AdapterPage.tsx
@@ -123,11 +123,34 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
         });
     }
 
-
+    function addFabDefaultSection() {
+        const condition = data.sections.find(section => section.name === "FabDefault");
+        if (data.sections) {
+            if (!condition) {
+                data.sections.push({
+                    name: "FabDefault",
+                    title: "Default Section",
+                    hideTitle: true
+                })
+            }
+        } else {
+            data.sections = [{
+                name: "FabDefault",
+                title: "Default Section",
+                hideTitle: true
+            }]
+        }
+        data.pages.forEach(page => {
+            if (!page.section) {
+                page.section = "FabDefault"
+            }
+        });
+    }
 
     if (data.pages) {
-        updateMultiInputField();
+        addFabDefaultSection();
         updateSectionsOnConditions();
+        updateMultiInputField();
     }
 
     const publishAndDirectToPreview = async (_e) => {

--- a/e2e-test/cypress/e2e/designer/startPage.feature
+++ b/e2e-test/cypress/e2e/designer/startPage.feature
@@ -26,7 +26,7 @@ Feature: Start Page
     When I choose "Open an existing form"
     And I submit the form with the button title "Next"
     And I force open the link "test"
-    Then I see the heading "Start"
+    Then I see the exact heading "Start"
 
   Scenario: Open an existing form duplicates the form with a different ID
     Given I am on the form designer start page

--- a/e2e-test/cypress/e2e/formPages.feature
+++ b/e2e-test/cypress/e2e/formPages.feature
@@ -20,9 +20,18 @@ Feature: Form pages
     * I preview the page "First page" without href
     Then I see the path is "/my-first-test-page"
 
+  @wip # Since we are adding a default section now this feature will be not there instead need to section button to create section
   Scenario: Create a section from Edit page
     And I edit the page "First page"
     When I create a section titled "Personal Details"
+    And I preview the page "First page" without href
+    Then I see the section title "Personal Details" is displayed in the preview
+
+  Scenario: Create a section from sections
+    When I open "Sections"
+    And I am creating a section title "Personal Details" and name "personalDetails"
+    And I edit the page "First page"
+    And I am adding the section to the page "First page" and section "personalDetails"
     And I preview the page "First page" without href
     Then I see the section title "Personal Details" is displayed in the preview
 

--- a/e2e-test/cypress/e2e/formPages.feature
+++ b/e2e-test/cypress/e2e/formPages.feature
@@ -20,7 +20,7 @@ Feature: Form pages
     * I preview the page "First page" without href
     Then I see the path is "/my-first-test-page"
 
-  @wip # Since we are adding a default section now this feature will be not there instead need to section button to create section
+  @wip # Since we are adding a default section now this feature will be not available instead need to use section button to create section check below scenario 
   Scenario: Create a section from Edit page
     And I edit the page "First page"
     When I create a section titled "Personal Details"

--- a/e2e-test/cypress/support/step_definitions/runner/I_am_creating_a_section .js
+++ b/e2e-test/cypress/support/step_definitions/runner/I_am_creating_a_section .js
@@ -1,0 +1,14 @@
+import { Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("I am creating a section title {string} and name {string}", (sectionTitle, sectionName) => {
+  cy.contains('a', 'Add section').click();
+  cy.get('#section-title').type(sectionTitle);
+  cy.get('#section-name').clear().type(sectionName);
+  cy.findByRole("button", { name: "Save" }).click();
+  cy.findByText("Close").click();
+});
+
+Then("I am adding the section to the page {string} and section {string}", (pageName, sectionName) => {
+  cy.get('#page-section').select(sectionName);
+  cy.findByRole("button", { name: "Save" }).click();
+});

--- a/e2e-test/cypress/support/step_definitions/runner/i_see_the_heading_string.js
+++ b/e2e-test/cypress/support/step_definitions/runner/i_see_the_heading_string.js
@@ -1,0 +1,13 @@
+import { Then } from "@badeball/cypress-cucumber-preprocessor";
+
+Then("I see the exact heading {string}", (string) => {
+  cy.get(".page__heading h3")
+    .invoke("contents") // Gets all content inside h3, including nodes
+    .then((elements) => {
+      // Filter out any nodes that are span elements
+      const text = Cypress._.map(elements, (el) => {
+        return el.nodeType === Node.TEXT_NODE ? el.textContent.trim() : "";
+      }).join(""); // Join all filtered text nodes
+      expect(text).to.include(string); // Check if the filtered text includes "Start"
+    });
+});


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FS-4777


### Change description
According to the runner code, conditions are checked based on sections. However, if the user decides to change their answers on the last page (the Summary page), these conditions are not immediately checked. This is because reaching the Summary page indicates the user has completed the form journey. If the user later chooses to modify an answer, especially one that affects the journey, the runner will return to the Summary page. Here, it will assess whether any mandatory answers are missing, and if so, prompt the user to complete these answers before moving on to the next required page and it will continue this till reaching the end.

And to fix this I have introduced a default section

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
