### PR TITLE
FS-4779-fix first page not selecting issue

### DIFF
--- a/designer/client/components/Page/AdapterPage.tsx
+++ b/designer/client/components/Page/AdapterPage.tsx
@@ -147,10 +147,24 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
         });
     }
 
+    function updateFirstPage() {
+        const allPaths = data.pages.map(page => page.path)
+        const usedPaths = new Set();
+        data.pages.forEach(page => {
+            if (page.next) {
+                page.next.forEach(link => {
+                    usedPaths.add(link.path)
+                })
+            }
+        })
+        data.startPage = allPaths.filter(item => !usedPaths.has(item))[0];
+    }
+
     if (data.pages) {
         addFabDefaultSection();
         updateSectionsOnConditions();
         updateMultiInputField();
+        updateFirstPage();
     }
 
     const publishAndDirectToPreview = async (_e) => {


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FS-4779

### Change description
When a user tries to create a new form as a template, the form initially displays a three-page view: First Page -> Second Page -> Summary. However, if the user adds a new page and wants to set it as the first page, the form's JSON does not update the startPage to reflect this change.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
