### PR TITLE
In summary page data change gives a 404 while trying to complete after the data change

### DIFF
--- a/runner/src/server/plugins/engine/api/RegisterFormPublishApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterFormPublishApi.ts
@@ -239,7 +239,7 @@ export class RegisterFormPublishApi implements RegisterApi {
 
             if (model) {
                 const page = model.pages.find(
-                    (page) => page.path.replace(/^\//, "") === path
+                    (page) => page.path.replace(/^\//, "") === path.replace(/^\//, "")
                 );
 
                 if (page) {


### PR DESCRIPTION

### Change description
When a user wants to change the data from the summary page, and then he comes back and tries to save it gives a 404 since it cannot detect the last page because of the / we have, so with this change we are going to ignore the / that we have 

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
