### PR TITLE
Don't deploy with recreate

### DIFF
--- a/copilot/fsd-form-designer-adapter/manifest.yml
+++ b/copilot/fsd-form-designer-adapter/manifest.yml
@@ -66,7 +66,5 @@ environments:
     count:
       spot: 1
   test:
-    deployment:
-      rolling: "recreate"
     count:
       spot: 2

--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -85,8 +85,6 @@ environments:
   test:
     variables:
       PREVIEW_MODE: true
-    deployment:
-      rolling: "recreate"
     count:
       spot: 2
   uat:


### PR DESCRIPTION
This is because the `recreate` deployment method leads to downtime, which can disrupt our users (internally). It is not any faster than a normal deployment, and causes tests to break. I am not sure why it was chosen to begin with.

https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#deployment-rolling