### PR TITLE
FLS-823: feature/redirect-to-eligible-round

### DIFF
--- a/runner/src/server/plugins/engine/page-controllers/ConfirmPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/ConfirmPageController.ts
@@ -21,7 +21,23 @@ export class ConfirmPageController extends SummaryPageController {
             const state = await adapterCacheService.getState(request);
             const fund_name = state["metadata"]["fund_name"];
             const round_name = state["metadata"]["round_name"];
-            return redirectTo(request, h, config.eligibilityResultUrl + "/" + fund_name + "/" + round_name);
+
+            let question_answer_short_code;
+
+            // get the question_answer_short_code (round shortname to redirect to) if it was included in the funds eligibility questions
+            for (let [, section] of Object.entries(state)) {
+                if (section && section["redirectToEligibleRound"]) {
+                    question_answer_short_code = section["redirectToEligibleRound"];
+                }
+            }
+
+            const url = new URL(`${config.eligibilityResultUrl}/${fund_name}/${round_name}`)
+
+            if (question_answer_short_code) {
+                url.searchParams.set('redirect_to_eligible_round', question_answer_short_code)
+            }
+
+            return redirectTo(request, h, url.href)
         };
     }
 }

--- a/runner/src/server/plugins/engine/page-controllers/ConfirmPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/ConfirmPageController.ts
@@ -4,6 +4,8 @@ import {redirectTo} from "../util/helper";
 import {AdapterFormModel} from "../models";
 import {SummaryPageController} from "./SummaryPageController";
 
+const REDIRECT_TO_ELIGIBLE_ROUND_QUESTION_KEY = "redirectToEligibleRound";
+
 export class ConfirmPageController extends SummaryPageController {
     // Controller to add confirm and continue button
     // @ts-ignore
@@ -22,19 +24,19 @@ export class ConfirmPageController extends SummaryPageController {
             const fund_name = state["metadata"]["fund_name"];
             const round_name = state["metadata"]["round_name"];
 
-            let question_answer_short_code;
+            let eligibleRoundRedirectAnswerShortCode;
 
-            // get the question_answer_short_code (round shortname to redirect to) if it was included in the funds eligibility questions
+            // get the eligibleRoundRedirectAnswerShortCode (round to redirect to) if it was included in the funds eligibility questions
             for (let [, section] of Object.entries(state)) {
-                if (section && section["redirectToEligibleRound"]) {
-                    question_answer_short_code = section["redirectToEligibleRound"];
+                if (section && section[REDIRECT_TO_ELIGIBLE_ROUND_QUESTION_KEY]) {
+                    eligibleRoundRedirectAnswerShortCode = section[REDIRECT_TO_ELIGIBLE_ROUND_QUESTION_KEY];
                 }
             }
 
             const url = new URL(`${config.eligibilityResultUrl}/${fund_name}/${round_name}`)
 
-            if (question_answer_short_code) {
-                url.searchParams.set('redirect_to_eligible_round', question_answer_short_code)
+            if (eligibleRoundRedirectAnswerShortCode) {
+                url.searchParams.set('redirect_to_eligible_round', eligibleRoundRedirectAnswerShortCode)
             }
 
             return redirectTo(request, h, url.href)


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-823

Description:

This update addresses the new HSRA requirements, which involve two different application task lists. We create a round for each task list and use eligibility questions to determine which round to redirect the user to based on their answer.

### Change description
- We check the eligibility questions for the answer to a specific question.
- If the question exists, we retrieve its value (the round short code).
- We then pass this value to the frontend as a redirect_to_eligible_round parameter.
- This parameter is used to decide which application task list to display.

- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Log in to the apply service to a fund that includes eligibility questions before starting an application.
- Ensure you are redirected to the correct task list based on the answer to the specific eligibility question that determines the round/task list redirection.


### Screenshots of UI changes (if applicable)

<img width="1229" alt="Screenshot 2024-12-04 at 11 45 38" src="https://github.com/user-attachments/assets/fce97cc0-b2f0-491f-9d89-774155af7c8e">


<img width="1152" alt="Screenshot 2024-12-04 at 11 46 42" src="https://github.com/user-attachments/assets/59367f2d-c33a-4135-b961-fea637c48603">


<img width="1182" alt="Screenshot 2024-12-04 at 11 47 07" src="https://github.com/user-attachments/assets/239d4014-5cfc-4499-8207-31a235eda9b6">


<img width="1091" alt="Screenshot 2024-12-04 at 11 47 26" src="https://github.com/user-attachments/assets/b09622f9-bba4-4d56-8072-4af87c2147db">


<img width="1097" alt="Screenshot 2024-12-04 at 11 47 48" src="https://github.com/user-attachments/assets/a9225725-62d3-4568-80f9-06ad936c8c17">


<img width="1102" alt="Screenshot 2024-12-04 at 11 48 14" src="https://github.com/user-attachments/assets/2b3d595e-f9d4-4404-a867-2429076bf669">


<img width="1175" alt="Screenshot 2024-12-04 at 11 48 46" src="https://github.com/user-attachments/assets/b233eea6-952a-493f-bb51-77f9ae986f51">


<img width="1039" alt="Screenshot 2024-12-04 at 11 49 02" src="https://github.com/user-attachments/assets/c1aa638a-767f-41b4-9d58-fef656e7b0ca">


<img width="1057" alt="Screenshot 2024-12-04 at 11 49 21" src="https://github.com/user-attachments/assets/3d9ef43b-3b53-4e7d-87b1-69610b530127">
