### PR TITLE
FS-4870: adding prefixes and suffix along with the value in the last page (summary)

### DIFF
--- a/runner/src/server/plugins/engine/models/ViewModelBase.ts
+++ b/runner/src/server/plugins/engine/models/ViewModelBase.ts
@@ -445,12 +445,11 @@ function Item(
         title: component.title,
         dataType: component.dataType,
         immutable: component.options.disableChangingFromSummary,
+        prefix: component.options && component.options.prefix ? component.options.prefix: "",
+        suffix: component.options && component.options.suffix ? component.options.suffix: "",
     };
 
-    if (
-        component.type === "FileUploadField" &&
-        model.showFilenamesOnSummaryPage
-    ) {
+    if (component.type === "FileUploadField" && model.showFilenamesOnSummaryPage && sectionState.originalFilenames) {
         //@ts-ignore
         item.filename = sectionState.originalFilenames[component.name]?.originalFilename;
     }

--- a/runner/src/server/views/partials/summary-row.html
+++ b/runner/src/server/views/partials/summary-row.html
@@ -10,7 +10,7 @@
                     {{itemValue}}<br>
                 {% endfor %}
             {% elif item.type == 'NumberField' or item.type == 'WebsiteField' and 'http' not in item.value|lower %}
-                {{item.prefix}}{{item.value}}
+                {{item.prefix}} {{item.value}} {{item.suffix}}
             {% elif item.type == 'ClientSideFileUploadField' %}
                 {% if item.value.files|length == 0 %}
                     {{ notSuppliedText }}

--- a/runner/test/cases/server/plugins/engine/page-controllers/SummaryPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/SummaryPageController.test.ts
@@ -1,0 +1,157 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import * as path from "path";
+import * as sinon from "sinon";
+//@ts-ignore
+import {AdapterFormModel} from "src/server/plugins/engine/models";
+//@ts-ignore
+import createServer from "src/server";
+//@ts-ignore
+import {StartPageController} from "src/server/plugins/engine/page-controllers";
+//@ts-ignore
+import {TranslationLoaderService} from "src/server/services/TranslationLoaderService";
+import {PluginUtil} from "../../../../../../src/server/plugins/engine/util/PluginUtil";
+
+import form from "../../../prefix-postfix-for-fields.test.json";
+
+const {expect} = Code;
+const lab = Lab.script();
+exports.lab = lab;
+const {suite, test, before, after, beforeEach, afterEach} = lab;
+
+suite("SummaryPageController", () => {
+    let server;
+    let sandbox;
+
+    const mockI18n = (key) => {
+        const translationService: TranslationLoaderService = new TranslationLoaderService();
+        const translations = translationService.getTranslations();
+        return translations.en[key] || key;
+    };
+
+    before(async () => {
+        server = await createServer({
+            formFileName: "prefix-postfix-for-fields.test.json",
+            formFilePath: path.join(__dirname, "../../../"),
+            enforceCsrf: false,
+        });
+        server.i18n = {
+            __: mockI18n
+        };
+    });
+
+    after(async () => {
+        await server.stop();
+    });
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    test("shouldAddingPreFixesForTheSummaryIfThereAreAnyPrefixes", async () => {
+        const pages = [...form.pages];
+        const firstPage = pages.shift();
+        const formDef = {...form, pages: [firstPage, ...pages]};
+        let formModel = new AdapterFormModel(formDef, {});
+        const page = formModel.pages.find(
+            (page) => PluginUtil.normalisePath(page.path) === PluginUtil.normalisePath("summary")
+        );
+
+        const mockState = {
+            progress: ["/xwFi2C2S-Y/management-case-oqAeVI", "/xwFi2C2S-Y/management-case-kYpnwk"],
+            FabDefault: {
+                TzOokX: [{
+                    GpLJDu: "Natalie Watkins",
+                    RRzTlc: 148
+                }, {
+                    GpLJDu: "sdf",
+                    RRzTlc: 4
+                }],
+                iyTJRX: 45,
+                IdoZHN: 4343
+            },
+            webhookData: {
+                metadata: {},
+                name: "Apply for funding to save an asset in your community",
+                questions: [{
+                    category: "FabDefault",
+                    question: "Management case",
+                    fields: [{
+                        key: "TzOokX",
+                        title: "Sources of income",
+                        type: "multiInput",
+                        answer: [{
+                            GpLJDu: "Natalie Watkins",
+                            RRzTlc: 148
+                        }, {
+                            GpLJDu: "sdf",
+                            RRzTlc: 4
+                        }]
+                    }, {
+                        key: "iyTJRX",
+                        title: "How many years old ",
+                        type: "text",
+                        answer: "45"
+                    }, {
+                        key: "IdoZHN",
+                        title: "Amount your salary ?",
+                        type: "text",
+                        answer: "4343"
+                    }]
+                }]
+            }
+        };
+        // Mock adapterCacheService with the methods you need
+        const mockAdapterCacheService: any = {
+            getState: sinon.stub().resolves(mockState),
+        };
+        // Mock request with state
+        const request = {
+            services: sinon.stub().returns({
+                adapterCacheService: mockAdapterCacheService,
+            }),
+            query: {
+                lang: "en"
+            },
+            yar: {
+                get: sinon.stub().returns("en"),
+                flash: sinon.stub().returns("en")
+            },
+            logger: {
+                info: sinon.stub().returns("logger")
+            },
+            i18n: {
+                __: sinon.stub().returns("english text"),
+                getLocale: sinon.stub().returns("en")
+            },
+            auth: {
+                isAuthenticated: false
+            }
+        };
+
+        // Mock Hapi response toolkit
+        const h = {
+            response: sinon.stub().returns({
+                code: sinon.stub()
+            }),
+            redirect: sinon.stub(),
+            view: sinon.stub().callsFake(async (_templateName, contextData) => {
+                // Call server.render with the same arguments
+                expect(contextData.details).exist();
+                expect(contextData.details[0]).exist();
+                expect(contextData.details[0].items).exist();
+                expect(contextData.details[0].items[0].value[0]).to.contains("Natalie Watkins : £148");
+                expect(contextData.details[0].items[0].value[1]).to.contains("sdf : £4");
+                expect(contextData.details[0].items[1].value).to.contains("45");
+                expect(contextData.details[0].items[1].suffix).to.contains("years");
+                expect(contextData.details[0].items[2].prefix).to.contains("£");
+                expect(contextData.details[0].items[2].value).to.contains("4343");
+            }),
+        };
+        await page.makeGetRouteHandler()(request, h);
+    });
+});

--- a/runner/test/cases/server/prefix-postfix-for-fields.test.json
+++ b/runner/test/cases/server/prefix-postfix-for-fields.test.json
@@ -1,0 +1,173 @@
+{
+  "metadata": {},
+  "startPage": "/management-case-oqAeVI",
+  "pages": [
+    {
+      "path": "/management-case-kYpnwk",
+      "controller": "RepeatingFieldPageController",
+      "options": {
+        "summaryDisplayMode": {
+          "samePage": true,
+          "separatePage": false,
+          "hideRowTitles": false
+        },
+        "customText": {
+          "samePageTitle": "Your income sources",
+          "samePageTableItemName": ""
+        }
+      },
+      "title": "Management case",
+      "components": [
+        {
+          "name": "FHZRAe",
+          "options": {},
+          "type": "Html",
+          "content": "<h2 class=\"govuk-heading-m\">Income to run the asset</h2>",
+          "schema": {}
+        },
+        {
+          "name": "fzAoYw",
+          "options": {},
+          "type": "Details",
+          "content": "<p>We're looking to understand your full financial forecasts for running the asset once you take ownership.</p>\n\n<p> This includes your sources of income and regular costs, as well as a summary of your expected cash flow for the next few years.</p>\n<p>We also need to make sure you're confident you will spend any money awarded by this fund within 12 months.</p>\n\n<p>You can use your business plan to provide information that supports your answers.</p>",
+          "title": "Help with project costs",
+          "schema": {}
+        },
+        {
+          "name": "adkAXU",
+          "options": {},
+          "type": "Para",
+          "content": "<h2 class=\"govuk-heading-s\">Income sources</h2>\n<p class=\"govuk-caption-m\">This is how you expect the asset to make money in future. These should be measured against your running costs.</p>\n<p class=\"govuk-caption-m\">You can use your business plan to provide information that supports your answers.</p>",
+          "schema": {}
+        },
+        {
+          "name": "TzOokX",
+          "options": {
+            "prefix": "£",
+            "columnTitles": [
+              "Source",
+              "Amount",
+              "Action"
+            ],
+            "required": true
+          },
+          "type": "MultiInputField",
+          "title": "Sources of income",
+          "hint": "The MultiInputField needed",
+          "schema": {},
+          "children": [
+            {
+              "name": "GpLJDu",
+              "options": {},
+              "type": "TextField",
+              "title": "Source"
+            },
+            {
+              "name": "RRzTlc",
+              "options": {
+                "prefix": "£",
+                "classes": "govuk-!-width-one-half"
+              },
+              "type": "NumberField",
+              "title": "Amount in pounds",
+              "hint": "",
+              "schema": {}
+            }
+          ]
+        },
+        {
+          "name": "iyTJRX",
+          "options": {
+            "suffix": "years"
+          },
+          "type": "NumberField",
+          "title": "How many years old ",
+          "schema": {
+            "min": "10",
+            "max": "100"
+          }
+        },
+        {
+          "name": "IdoZHN",
+          "options": {
+            "prefix": "£"
+          },
+          "type": "NumberField",
+          "title": "Amount your salary ?",
+          "schema": {
+            "min": "10",
+            "max": "10000"
+          }
+        }
+      ],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ],
+      "section": "FabDefault"
+    },
+    {
+      "path": "/summary",
+      "title": "Check your answers",
+      "components": [],
+      "next": [],
+      "controller": "./pages/summary.js",
+      "section": "FabDefault"
+    },
+    {
+      "path": "/management-case-oqAeVI",
+      "title": "Management case",
+      "components": [
+        {
+          "name": "mPqjks",
+          "options": {},
+          "type": "Html",
+          "content": "<h2 class=\"govuk-heading-m\">Project costs</h2>",
+          "schema": {}
+        },
+        {
+          "name": "UplABn",
+          "options": {},
+          "type": "Para",
+          "content": "<label class=\"govuk-!-font-weight-bold\">In this section, we'll ask about:\n</label>\n\n<ul class=\"govuk-list govuk-list--bullet\">\n<li>cash flow summary</li>\n<li>income sources</li>\n<li>running costs</li>\n</ul>\n",
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/management-case-kYpnwk"
+        }
+      ],
+      "controller": "./pages/start.js",
+      "section": "FabDefault"
+    }
+  ],
+  "lists": [],
+  "sections": [
+    {
+      "name": "FabDefault",
+      "title": "Default Section",
+      "hideTitle": true
+    }
+  ],
+  "conditions": [],
+  "fees": [],
+  "outputs": [],
+  "version": 2,
+  "skipSummary": false,
+  "name": "Apply for funding to save an asset in your community",
+  "feedback": {
+    "feedbackForm": false,
+    "url": ""
+  },
+  "phaseBanner": {
+    "phase": "beta"
+  },
+  "feeOptions": {
+    "allowSubmissionWithoutPayment": true,
+    "maxAttempts": 3,
+    "showPaymentSkippedWarningPage": false
+  },
+  "markAsComplete": false
+}


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FS-4870


### Change description
When user completes a form and in some of the pages it asks data with prefixes or post fixes like `£` or `years` so in this fix we are going to show the relevant post fix or prefix along with the data in the summary page and this should not brake any other functionalities that exists in the runner.

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
01. Log in into any of the COF25 rounds go to Funding required subsection and fill them with data 
02. See the last page and if the last page has the prefixes or suffixes that is the behaviour for the reference attaching screenshots 

### Screenshots of UI changes (if applicable)


