### PR TITLE
Integrate frontend and fix deployment

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -365,6 +365,7 @@ jobs:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy ]
     permissions:
       id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
@@ -421,6 +422,7 @@ jobs:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy ]
     permissions:
       id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )  }}
 
     secrets:
@@ -476,6 +478,7 @@ jobs:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy ]
     permissions:
       id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
     if: ${{ always()  && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )  }}
     secrets:
       FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}

--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -61,7 +61,7 @@ variables:
   JWT_REDIRECT_TO_AUTHENTICATION_URL: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/sessions/sign-out"
   LOGOUT_URL: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/sessions/sign-out"
   MULTIFUND_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"
-  NODE_CONFIG: '{"safelist": ["fsd-application-store", "fsd-pre-award-stores"]}'
+  NODE_CONFIG: '{"safelist": ["fsd-application-store", "fsd-pre-award-stores", "fsd-pre-award"]}'
   NODE_ENV: production
   PRIVACY_POLICY_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/privacy"
   SERVICE_START_PAGE: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-204

### Change description
Adds the new `fsd-pre-award` deployed service to the form runner whitelist.

Also, we need to give these permissions to the workflow after merging [this update to the deployment pipeline](https://github.com/communitiesuk/funding-service-design-workflows/pull/223).