### PR TITLE
Add new safe callback host

### DIFF
--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -61,7 +61,7 @@ variables:
   JWT_REDIRECT_TO_AUTHENTICATION_URL: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/sessions/sign-out"
   LOGOUT_URL: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/sessions/sign-out"
   MULTIFUND_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"
-  NODE_CONFIG: '{"safelist": ["fsd-application-store", "fsd-pre-award-stores", "fsd-pre-award"]}'
+  NODE_CONFIG: '{"safelist": ["fsd-application-store", "fsd-pre-award-stores", "fsd-pre-award", "fsd-pre-award.${COPILOT_ENVIRONMENT_NAME}.pre-award.local"]}'
   NODE_ENV: production
   PRIVACY_POLICY_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/privacy"
   SERVICE_START_PAGE: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-207

We're switching from serving the pre-award internal/private API on `fsd-pre-award` to `fsd-pre-award.env.pre-award.local`, the latter of which is available to ECS scheduled tasks as well as full services.

We need the API to be available for scheduled tasks because the post-award download-report job runs this way and needs to read from the account-store API.