### PR TITLE
FS-4942: enable https configuration in designer server side to enable https from docker runner side

### DIFF
--- a/designer/server/config.ts
+++ b/designer/server/config.ts
@@ -29,6 +29,8 @@ export interface Config {
     authServiceUrl: string,
     rsa256PublicKeyBase64: string,
     authCookieName: string,
+    sslKey: string,
+    sslCert: string,
 }
 
 // server-side storage expiration - defaults to 20 minutes
@@ -61,6 +63,8 @@ const schema = joi.object({
     authServiceUrl: joi.string().optional(),
     rsa256PublicKeyBase64: joi.string().optional(),
     authCookieName: joi.string().optional(),
+    sslKey: joi.string().optional(),
+    sslCert: joi.string().optional(),
 });
 
 // Build config
@@ -84,6 +88,8 @@ const config = {
     authServiceUrl: process.env.AUTH_SERVICE_URL,
     rsa256PublicKeyBase64: process.env.RSA256_PUBLIC_KEY_BASE64,
     authCookieName: process.env.AUTH_COOKIE_NAME,
+    sslKey: process.env.SSL_KEY,
+    sslCert: process.env.SSL_CERT,
 };
 
 // Validate config

--- a/designer/server/createServer.ts
+++ b/designer/server/createServer.ts
@@ -1,20 +1,23 @@
-import hapi from "@hapi/hapi";
+import hapi, {ServerOptions} from "@hapi/hapi";
 import inert from "@hapi/inert";
 import Scooter from "@hapi/scooter";
 import logging from "../../digital-form-builder/designer/server/plugins/logging";
 import router from "../../digital-form-builder/designer/server/plugins/router";
 import {viewPlugin} from "../../digital-form-builder/designer/server/plugins/view";
 import Schmervice from "schmervice";
-import config from "../../digital-form-builder/designer/server/config";
 import {determinePersistenceService} from "../../digital-form-builder/designer/server/lib/persistence";
 import {configureBlankiePlugin} from "../../digital-form-builder/designer/server/plugins/blankie";
 import {configureYarPlugin} from "../../digital-form-builder/designer/server/plugins/session";
 import {designerPlugin} from "./plugins/DesignerRouteRegister";
 import errorHandlerPlugin from "./plugins/ErrorHandlerPlugin";
 import authPlugin from "./plugins/AuthPlugin";
+import fs from "fs";
+import config from "./config";
 
 const serverOptions = () => {
-    return {
+    const hasCertificate = config.sslKey && config.sslCert;
+
+    const serverOptions: ServerOptions = {
         port: process.env.PORT || 3000,
         router: {
             stripTrailingSlash: true,
@@ -36,6 +39,20 @@ const serverOptions = () => {
                 xframe: true,
             },
         },
+    };
+
+    const httpsOptions = hasCertificate
+        ? {
+            tls: {
+                key: fs.readFileSync(config.sslKey),
+                cert: fs.readFileSync(config.sslCert),
+            },
+        }
+        : {};
+
+    return {
+        ...serverOptions,
+        ...httpsOptions,
     };
 };
 


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-4942**


### Change description
Designer it was only can be started as http but in the local setup (docker runner) it has https enabled for all most every service so better to have same implementation in designer so added these configurations and runner already has these configurations in it

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
