### PR TITLE
FSPT-220: Enable Slack notification on failed deploys

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -326,40 +326,27 @@ jobs:
           fi
 
   dev_deploy:
-    strategy:
-      matrix:
-        include:
-          - deployment: fsd-form-runner-adapter
-            command: svc
-            appname: "form-runner-adapter"
-          - deployment: fsd-form-designer-adapter
-            command: svc
-            appname: "form-designer-adapter"
+    needs: [ setup, docker-designer-build, docker-runner-build ]
+    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    needs: [ setup, docker-designer-build, docker-runner-build ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
-    runs-on: ubuntu-latest
-    environment: dev
-    steps:
-      - name: Git clone the repository
-        uses: actions/checkout@v4
-
-      - name: Setup Copilot
-        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
-        with:
-          environment: dev
-          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-
-      - name: Inject env specific values into manifest
-        run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-          yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-${{ matrix.appname }}:sha-${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-
-      - name: Copilot deploy ${{ matrix.deployment }}
-        run: |
-          copilot ${{ matrix.command }} deploy --name ${{ matrix.deployment }}
+    strategy:
+      matrix:
+        include:
+          - appname: "form-runner-adapter"
+            image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
+          - appname: "form-designer-adapter"
+            image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+    with:
+      environment: dev
+      app_name: ${{ matrix.appname }}
+      run_db_migrations: false
+      image_location: ${{ matrix.image_location }}
+      notify_slack: false
 
   post_dev_deploy_tests:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy ]
@@ -381,42 +368,32 @@ jobs:
       run_zap_scan: true
       app_name: forms
       environment: dev
+      notify_slack: false
 
   test_deploy:
-    strategy:
-      matrix:
-        include:
-          - deployment: fsd-form-runner-adapter
-            command: svc
-            appname: "form-runner-adapter"
-          - deployment: fsd-form-designer-adapter
-            command: svc
-            appname: "form-designer-adapter"
+    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, post_dev_deploy_tests ]
+    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, post_dev_deploy_tests ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
-    runs-on: ubuntu-latest
-    environment: test
-    steps:
-      - name: Git clone the repository
-        uses: actions/checkout@v4
-
-      - name: Setup Copilot
-        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
-        with:
-          environment: test
-          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-
-      - name: Inject env specific values into manifest
-        run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-          yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-${{ matrix.appname }}:sha-${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-
-      - name: Copilot deploy ${{ matrix.deployment }}
-        run: |
-          copilot ${{ matrix.command }} deploy --name ${{ matrix.deployment }}
+    strategy:
+      matrix:
+        include:
+          - appname: "form-runner-adapter"
+            image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
+          - appname: "form-designer-adapter"
+            image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+    with:
+      environment: test
+      app_name: ${{ matrix.appname }}
+      run_db_migrations: false
+      image_location: ${{ matrix.image_location }}
+      notify_slack: true
 
   post_test_deploy_tests:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy ]
@@ -431,6 +408,8 @@ jobs:
       FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
       FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
     with:
       run_performance_tests: ${{ inputs.run_performance_tests || true }}
@@ -440,39 +419,25 @@ jobs:
       run_zap_scan: true
       app_name: forms
       environment: test
-
+      notify_slack: true
+  
   uat_deploy:
-    strategy:
-      matrix:
-        include:
-          - deployment: fsd-form-runner-adapter
-            command: svc
-            appname: "form-runner-adapter"
+    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, post_test_deploy_tests ]
+    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, post_test_deploy_tests ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
-    runs-on: ubuntu-latest
-    environment: uat
-    steps:
-      - name: Git clone the repository
-        uses: actions/checkout@v4
-
-      - name: Setup Copilot
-        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
-        with:
-          environment: uat
-          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-
-      - name: Inject env specific values into manifest
-        run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-          yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-${{ matrix.appname }}:sha-${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-
-      - name: Copilot deploy ${{ matrix.deployment }}
-        run: |
-          copilot ${{ matrix.command }} deploy --name ${{ matrix.deployment }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+    with:
+      environment: uat
+      app_name: form-runner-adapter
+      run_db_migrations: false
+      image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
+      notify_slack: true
 
   post_uat_deploy_tests:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy ]
@@ -486,6 +451,8 @@ jobs:
       FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
       FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
     with:
       run_performance_tests: ${{ inputs.run_performance_tests || true }}
@@ -495,37 +462,23 @@ jobs:
       run_zap_scan: true
       app_name: forms
       environment: uat
+      notify_slack: true
 
   prod_deploy:
-    strategy:
-      matrix:
-        include:
-          - deployment: fsd-form-runner-adapter
-            command: svc
-            appname: "form-runner-adapter"
+    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy, post_uat_deploy_tests ]
+    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy, post_uat_deploy_tests ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
-    runs-on: ubuntu-latest
-    environment: prod
-    steps:
-      - name: Git clone the repository
-        uses: actions/checkout@v4
-
-      - name: Setup Copilot
-        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
-        with:
-          environment: prod
-          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-
-      - name: Inject env specific values into manifest
-        run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-          yq -i '.image.location = "ghcr.io/communitiesuk/funding-service-design-${{ matrix.appname }}:sha-${{ github.sha }}"'  copilot/${{ matrix.deployment }}/manifest.yml
-
-      - name: Copilot deploy ${{ matrix.deployment }}
-        run: |
-          copilot ${{ matrix.command }} deploy --name ${{ matrix.deployment }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    secrets:
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+    with:
+      environment: prod
+      app_name: form-runner-adapter
+      run_db_migrations: false
+      image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
+      notify_slack: true
 


### PR DESCRIPTION
Deploys to test, UAT and Prod will now trigger a Slack notification if the deployment fails as this would constitute a 'block' in the pipeline.

Relies on https://github.com/communitiesuk/funding-service-design-workflows/pull/231

Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-220