### PR TITLE
Adjust prod script

### DIFF
--- a/runner/package.json
+++ b/runner/package.json
@@ -12,7 +12,7 @@
     "copy-forms": "node copy-form-json.js",
     "clean:build": "rm -rf dist",
     "dev": "NODE_ENV=development nodemon --watch src --ext js,json,ts,html,scss --exec 'yarn build && node dist/digital-form-builder-adapter/runner/index.js'",
-    "start:server": "nodemon dist/digital-form-builder-adapter/runner/index.js",
+    "start:server": "node dist/digital-form-builder-adapter/runner/index.js",
     "production": "NODE_ENV=production npm run start:server",
     "start:test": "NODE_ENV=development npm run start:server",
     "test-cov": "yarn run unit-test-cov",


### PR DESCRIPTION
Adjust prod script.

From what I can see, `nodemon` even with the `NODE_ENV=production` it's still watching. 
If I do `make pre up` you would still see:
```
form-runner-1    | [nodemon] 2.0.22
form-runner-1    | [nodemon] to restart at any time, enter `rs`
form-runner-1    | [nodemon] watching path(s): dist/**/*
form-runner-1    | [nodemon] watching extensions: js,mjs,json
form-runner-1    | [nodemon] starting `node dist/digital-form-builder-adapter/runner/index.js`
```