### PR TITLE
BAU: Add snapshot retention window to Redis cache

### DIFF
--- a/copilot/fsd-form-runner-adapter/addons/form-runner-data.yml
+++ b/copilot/fsd-form-runner-adapter/addons/form-runner-data.yml
@@ -69,6 +69,8 @@ Resources:
         - !GetAtt "FormRunnerAdapterRedisSecurityGroup.GroupId"
       Engine: redis
       NumCacheClusters: 2
+      SnapshotRetentionLimit: 7
+      SnapshottingClusterId: !Join ["", [!Select [6, !Split [":", !GetAtt "FormRunnerAdapterRedisReplicationGroup.ARN"]], "-001"]]
 
   # Redis endpoint stored in SSM so that other services can retrieve the endpoint.
   FormRunnerAdapterRedisEndpointAddressParam:


### PR DESCRIPTION
The snapshot retention window for the AWS::ElastiCache::ReplicationGroup is 0 by default and therefore not enabled. This sets the window to 7 days retention so we have data backups.

_Add ticket reference to Pull Request title: e.g. 'FS-123: Add content', if there is no ticket prefix with BAU_


### Change description
_A brief description of the pull request_

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
