### PR TITLE
FSPT-228: add overrides on test environment

### DIFF
--- a/copilot/fsd-form-designer-adapter/manifest.yml
+++ b/copilot/fsd-form-designer-adapter/manifest.yml
@@ -76,6 +76,12 @@ environments:
     count:
       spot: 1
   test:
+    variables:
+      PREVIEW_URL: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+      AUTH_SERVICE_URL: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+    http:
+      alias: ['form-designer.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk', 'form-designer.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk']
+
     count:
       spot: 2
   uat:

--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -102,6 +102,18 @@ environments:
   test:
     variables:
       PREVIEW_MODE: true
+      ACCESSIBILITY_STATEMENT_URL: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/accessibility_statement"
+      CONTACT_US_URL: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/contact_us"
+      COOKIE_POLICY_URL: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/cookie_policy"
+      FEEDBACK_LINK: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/feedback"
+      JWT_REDIRECT_TO_AUTHENTICATION_URL: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/sessions/sign-out"
+      LOGOUT_URL: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/sessions/sign-out"
+      MULTIFUND_URL: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/account"
+      PRIVACY_POLICY_URL: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/privacy"
+      SERVICE_START_PAGE: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"
+      ELIGIBILITY_RESULT_URL: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/eligibility-result"
+    http:
+      alias: ['forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk', 'application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk']
     count:
       spot: 2
   uat:


### PR DESCRIPTION
### Change description
Adds overrides on test environment to migrate to test.communities.gov.uk domain

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
After deployment test environment should be accessible on test.communities.gov.uk domain


### Screenshots of UI changes (if applicable)
