### PR TITLE
FSPT-228: Consolidate aliases and test removing hosted zone

### DIFF
--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -11,7 +11,7 @@ http:
   path: "/"
   # You can specify a custom health check path. The default is "/".
   healthcheck: "/health-check"
-  alias: forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk
+  alias: ['forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk', 'application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk']
 
 # Configuration for your containers and service.
 image:
@@ -94,8 +94,6 @@ environments:
       PRIVACY_POLICY_URL: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/privacy"
       SERVICE_START_PAGE: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"
       ELIGIBILITY_RESULT_URL: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/eligibility-result"
-    http:
-      alias: ['forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk', 'application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk']
 
     count:
       spot: 2
@@ -112,8 +110,6 @@ environments:
       PRIVACY_POLICY_URL: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/privacy"
       SERVICE_START_PAGE: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/account"
       ELIGIBILITY_RESULT_URL: "https://apply.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/eligibility-result"
-    http:
-      alias: ['forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk', 'application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk']
     count:
       spot: 2
   uat:
@@ -132,7 +128,7 @@ environments:
       response_time: 2s
   prod:
     http:
-      alias: forms.access-funding.levellingup.gov.uk
+      alias: ['forms.access-funding.levellingup.gov.uk', 'application-questions.access-funding.communities.gov.uk']
       hosted_zone: Z0686469NF3ZJTU9I02M
     variables:
       ACCESSIBILITY_STATEMENT_URL: "https://frontend.access-funding.levellingup.gov.uk/accessibility_statement"


### PR DESCRIPTION
### Change description
Adds UAT and PROD aliases, ahead of communities migration.

Also tests removing the hosted zone (as we don't use it on post-award i.e. https://github.com/communitiesuk/funding-service-design-post-award-data-store/blob/504e6dbd3bc6943c602cc134ac3b432f426bca8e/copilot/post-award/manifest.yml#L81 and that seems to deploy without issue.) 

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should add UAT and PROD aliases, but the communities domains should 404 until other config changes are made.


### Screenshots of UI changes (if applicable)
