### PR TITLE
FSPT-228: fix duplicate manifest declaration

### DIFF
--- a/copilot/fsd-form-designer-adapter/manifest.yml
+++ b/copilot/fsd-form-designer-adapter/manifest.yml
@@ -56,8 +56,6 @@ variables:
   PREVIEW_URL: "https://forms.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   PUBLISH_URL: "http://fsd-form-runner-adapter:3009"
   AUTH_SERVICE_URL: "https://authenticator.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
-  PREVIEW_URL: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
-  AUTH_SERVICE_URL: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
   SSO_LOGIN_URL: "/sso/login?return_app=form-designer"
   SSO_LOGOUT_URL: "/sessions/sign-out"
   AUTH_COOKIE_NAME: "fsd_user_token"
@@ -70,9 +68,15 @@ secrets:
 # You can override any of the values defined above by environment.
 environments:
   dev:
+    variables:
+      PREVIEW_URL: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+      AUTH_SERVICE_URL: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
     count:
       spot: 1
   test:
+    variables:
+      PREVIEW_URL: "https://application-questions.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
+      AUTH_SERVICE_URL: "https://account.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk"
     count:
       spot: 2
   uat:


### PR DESCRIPTION
### Change description
We were erroneously duplicating this value. We only want to override in dev and test for now.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should deploy successfully

### Screenshots of UI changes (if applicable)
