### PR TITLE
FSPT-228: Remove hosted zone 

### DIFF
--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -129,7 +129,6 @@ environments:
   prod:
     http:
       alias: ['forms.access-funding.levellingup.gov.uk', 'application-questions.access-funding.communities.gov.uk']
-      hosted_zone: Z0686469NF3ZJTU9I02M
     variables:
       ACCESSIBILITY_STATEMENT_URL: "https://frontend.access-funding.levellingup.gov.uk/accessibility_statement"
       BASIC_AUTH_ON: false


### PR DESCRIPTION
### Change description
Remove hosted zone that was causing deployment failure. (see https://github.com/communitiesuk/digital-form-builder-adapter/actions/runs/13725475079/job/38478280552) I have tested with other services that this is not required and the service should deploy without it being set.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Should deploy successfully after merge 


### Screenshots of UI changes (if applicable)
