### PR TITLE
When the hide title status is false we should not show the title

### DIFF
--- a/runner/src/server/views/partials/summary-detail.html
+++ b/runner/src/server/views/partials/summary-detail.html
@@ -2,7 +2,7 @@
 
 {% macro summaryDetail(data, isReadOnlySummary=false) %}
     {%  set isRepeatableSection = (data.items[0] | isArray) %}
-    {% if not isRepeatableSection %}
+    {% if not isRepeatableSection and not data.hideTitle %}
         <h2 class="govuk-heading-m">{{data.title}}</h2>
     {% endif %}
   <dl class="govuk-summary-list">


### PR DESCRIPTION
When for the summary page has the default section attached that default section will have the `hideTitle:false` so we have to check that status before letting it to display on the summary page or any other pages 
