### PR TITLE
FS-4946: Prevent outdated deployments

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -384,25 +384,19 @@ jobs:
   dev_deploy:
     needs: [ setup, docker-designer-build, docker-runner-build ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'dev') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
+    concurrency:
+      group: 'fsd-adapter-dev'
+      cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    strategy:
-      matrix:
-        include:
-          - appname: "form-runner-adapter"
-            image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
-          - appname: "form-designer-adapter"
-            image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
     uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     with:
       environment: dev
-      app_name: ${{ matrix.appname }}
-      run_db_migrations: false
-      image_location: ${{ matrix.image_location }}
-      notify_slack: false
+      alert_slack_on_failure: false
+      notify_slack_on_deployment: false
 
   post_dev_deploy_tests:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy ]
@@ -429,16 +423,12 @@ jobs:
   test_deploy:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, post_dev_deploy_tests ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'test') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
+    concurrency:
+      group: 'fsd-adapter-test'
+      cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    strategy:
-      matrix:
-        include:
-          - appname: "form-runner-adapter"
-            image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
-          - appname: "form-designer-adapter"
-            image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
     uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
@@ -446,10 +436,8 @@ jobs:
       SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
     with:
       environment: test
-      app_name: ${{ matrix.appname }}
-      run_db_migrations: false
-      image_location: ${{ matrix.image_location }}
-      notify_slack: true
+      alert_slack_on_failure: true
+      notify_slack_on_deployment: false
 
   post_test_deploy_tests:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy ]
@@ -480,16 +468,12 @@ jobs:
   uat_deploy:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, post_test_deploy_tests ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
+    concurrency:
+      group: 'fsd-adapter-uat'
+      cancel-in-progress: false
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    strategy:
-      matrix:
-        include:
-          - appname: "form-runner-adapter"
-            image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
-          - appname: "form-designer-adapter"
-            image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
     uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
@@ -497,10 +481,8 @@ jobs:
       SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
     with:
       environment: uat
-      app_name: ${{ matrix.appname }}
-      run_db_migrations: false
-      image_location: ${{ matrix.image_location }}
-      notify_slack: true
+      alert_slack_on_failure: true
+      notify_slack_on_deployment: false
 
   post_uat_deploy_tests:
     needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy ]
@@ -533,7 +515,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    uses: ./.github/workflows/deploy.yml
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -394,7 +394,7 @@ jobs:
             image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
           - appname: "form-designer-adapter"
             image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     with:
@@ -439,7 +439,7 @@ jobs:
             image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
           - appname: "form-designer-adapter"
             image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -490,8 +490,7 @@ jobs:
             image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
           - appname: "form-designer-adapter"
             image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
-  
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -534,7 +533,7 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read # This is required for actions/checkout
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/standard-deploy.yml@main
+    uses: ./.github/workflows/deploy.yml
     secrets:
       AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,21 +2,10 @@ on:
     # Triggers the workflow on push or pull request events but only for the main branch
     workflow_call:
       inputs:
-        app_name:
-          required: false
-          type: string
         environment:
           required: true
           type: string
-        run_db_migrations:
-          required: false
-          default: false
-          type: boolean
-        image_location:
-          description: "Location of the image to deploy."
-          type: string
-          required: false
-        notify_slack:
+        alert_slack_on_failure:
           description: "Sends an alert to the prod alerts channel if deployment fails"
           required: true
           default: false
@@ -37,10 +26,14 @@ on:
           required: false
 jobs:
     deploy:
-      if: ${{ github.actor != 'dependabot[bot]' }}
-      concurrency:
-        group: 'fsd-preaward-${{ inputs.environment }}-{{inputs.app_name}}'
-        cancel-in-progress: false
+      name: ${{ matrix.app_name }}
+      strategy:
+        matrix:
+          include:
+            - app_name: "form-runner-adapter"
+              image_location: ghcr.io/communitiesuk/funding-service-design-form-runner-adapter:sha-${{ github.sha }}
+            - app_name: "form-designer-adapter"
+              image_location: ghcr.io/communitiesuk/funding-service-design-form-designer-adapter:sha-${{ github.sha }}
       permissions:
         id-token: write # This is required for requesting the JWT
         contents: read  # This is required for actions/checkout
@@ -50,22 +43,11 @@ jobs:
       - name: Git clone the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
   
-      - name: Get current date
-        shell: bash
-        id: currentdatetime
-        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-  
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+      - name: Setup Copilot
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/copilot_setup@main
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
-          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
-          aws-region: eu-west-2
-  
-      - name: Install AWS Copilot CLI
-        shell: bash
-        run: |
-          curl -Lo aws-copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x aws-copilot && sudo mv aws-copilot /usr/local/bin/copilot
+          copilot_environment: ${{ inputs.environment }}
+          AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
   
       - name: confirm copilot env
         shell: bash
@@ -77,11 +59,11 @@ jobs:
   
       - name: Inject Git SHA into manifest
         run: |
-          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/fsd-${{ inputs.app_name }}/manifest.yml
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/fsd-${{ matrix.app_name }}/manifest.yml
   
       - name: Inject replacement image into manifest
         run: |
-          yq -i ".image.location = \"${{ inputs.image_location }}\""  copilot/fsd-${{ inputs.app_name }}/manifest.yml
+          yq -i ".image.location = \"${{ matrix.image_location }}\""  copilot/fsd-${{ matrix.app_name }}/manifest.yml
   
       - name: Slack message for start of deployment
         id: slack_start_deployment_message
@@ -89,45 +71,41 @@ jobs:
         uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
         with:
           stage: 'start'
-          app_name: ${{ inputs.app_name }}
+          app_name: ${{ matrix.app_name }}
           environment: ${{ inputs.environment }}
           workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
   
-      - name: Run database migrations
-        id: db_migrations
-        if: ${{ inputs.run_db_migrations }}
-        run: scripts/migration-task-script.py ${{ inputs.environment }} ${{ inputs.image_location }}
-  
       - name: Copilot ${{ inputs.environment }} deploy
         id: deploy_build
         run: |
-          copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
-          copilot svc deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
+          copilot svc init --app pre-award --name fsd-${{ matrix.app_name }}
+          copilot svc deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ matrix.app_name }}
   
       - name: Slack message for end of deployment
         if: ${{ always() && inputs.notify_slack_on_deployment && steps.slack_start_deployment_message.outcome == 'success' }}
         uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
         with:
           stage: 'end'
-          app_name: ${{ inputs.app_name }}
+          app_name: ${{ matrix.app_name }}
           environment: ${{ inputs.environment }}
           workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
   
-          status: "${{ ( (steps.db_migrations.outcome == 'skipped' || steps.db_migrations.outcome == 'success') && steps.deploy_build.outcome == 'success') && 'success' || 'failed' }}"
+          status: "${{ ( steps.deploy_build.outcome == 'success') && 'success' || 'failed' }}"
           slack_message_ts: ${{ steps.slack_start_deployment_message.outputs.slack_start_message_ts }}
           deployment_start_ts: ${{ steps.slack_start_deployment_message.outputs.timestamp }}
   
     notify_slack:
+      name: Alert Slack if deployment fails
       needs:
         - deploy
-      if: ${{ inputs.notify_slack && always() && needs.deploy.result == 'failure' }}
-      uses: ./.github/workflows/notify-slack-deployment-failed.yml
+      if: ${{ inputs.alert_slack_on_failure && always() && needs.deploy.result == 'failure' }}
+      uses: communitiesuk/funding-service-design-workflows/.github/workflows/notify-slack-deployment-failed.yml@main
       with:
-        app_name: ${{ inputs.app_name }}
+        app_name: digital-form-builder-adapter
         env_name: ${{ inputs.environment }}
         github_username: ${{ github.actor }}
         workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,138 @@
+on:
+    # Triggers the workflow on push or pull request events but only for the main branch
+    workflow_call:
+      inputs:
+        app_name:
+          required: false
+          type: string
+        environment:
+          required: true
+          type: string
+        run_db_migrations:
+          required: false
+          default: false
+          type: boolean
+        image_location:
+          description: "Location of the image to deploy."
+          type: string
+          required: false
+        notify_slack:
+          description: "Sends an alert to the prod alerts channel if deployment fails"
+          required: true
+          default: false
+          type: boolean
+        notify_slack_on_deployment:
+          description: "Send messages to the deployments channel when deploys start+finish."
+          default: false
+          type: boolean
+      secrets:
+        AWS_ACCOUNT:
+          required: true
+        SLACK_BOT_TOKEN:
+          required: false
+        SLACK_NOTIFICATION_CHANNEL_ID:
+          required: false
+        SLACK_DEPLOYMENTS_CHANNEL_ID:
+          description: "[required if notify_slack_on_deployment=true]"
+          required: false
+jobs:
+    deploy:
+      if: ${{ github.actor != 'dependabot[bot]' }}
+      concurrency:
+        group: 'fsd-preaward-${{ inputs.environment }}-{{inputs.app_name}}'
+        cancel-in-progress: false
+      permissions:
+        id-token: write # This is required for requesting the JWT
+        contents: read  # This is required for actions/checkout
+      runs-on: ubuntu-latest
+      environment: ${{ inputs.environment }}
+      steps:
+      - name: Git clone the repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+  
+      - name: Get current date
+        shell: bash
+        id: currentdatetime
+        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+  
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubCopilotDeploy
+          role-session-name: "${{ inputs.app_name }}_${{ inputs.environemnt }}_copilot_${{ steps.currentdatetime.outputs.datetime }}"
+          aws-region: eu-west-2
+  
+      - name: Install AWS Copilot CLI
+        shell: bash
+        run: |
+          curl -Lo aws-copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x aws-copilot && sudo mv aws-copilot /usr/local/bin/copilot
+  
+      - name: confirm copilot env
+        shell: bash
+        run: |
+          if [ $(copilot env ls) != "${{ inputs.environment }}" ]; then
+            echo $(copilot env ls)
+            exit 1
+          fi
+  
+      - name: Inject Git SHA into manifest
+        run: |
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"'  copilot/fsd-${{ inputs.app_name }}/manifest.yml
+  
+      - name: Inject replacement image into manifest
+        run: |
+          yq -i ".image.location = \"${{ inputs.image_location }}\""  copilot/fsd-${{ inputs.app_name }}/manifest.yml
+  
+      - name: Slack message for start of deployment
+        id: slack_start_deployment_message
+        if: ${{ inputs.notify_slack_on_deployment }}
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
+        with:
+          stage: 'start'
+          app_name: ${{ inputs.app_name }}
+          environment: ${{ inputs.environment }}
+          workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
+  
+      - name: Run database migrations
+        id: db_migrations
+        if: ${{ inputs.run_db_migrations }}
+        run: scripts/migration-task-script.py ${{ inputs.environment }} ${{ inputs.image_location }}
+  
+      - name: Copilot ${{ inputs.environment }} deploy
+        id: deploy_build
+        run: |
+          copilot svc init --app pre-award --name fsd-${{ inputs.app_name }}
+          copilot svc deploy --env ${{ inputs.environment }} --app pre-award --name fsd-${{ inputs.app_name }}
+  
+      - name: Slack message for end of deployment
+        if: ${{ always() && inputs.notify_slack_on_deployment && steps.slack_start_deployment_message.outcome == 'success' }}
+        uses: communitiesuk/funding-service-design-workflows/.github/actions/slack_deployment_message@main
+        with:
+          stage: 'end'
+          app_name: ${{ inputs.app_name }}
+          environment: ${{ inputs.environment }}
+          workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel_id: ${{ secrets.SLACK_DEPLOYMENTS_CHANNEL_ID }}
+  
+          status: "${{ ( (steps.db_migrations.outcome == 'skipped' || steps.db_migrations.outcome == 'success') && steps.deploy_build.outcome == 'success') && 'success' || 'failed' }}"
+          slack_message_ts: ${{ steps.slack_start_deployment_message.outputs.slack_start_message_ts }}
+          deployment_start_ts: ${{ steps.slack_start_deployment_message.outputs.timestamp }}
+  
+    notify_slack:
+      needs:
+        - deploy
+      if: ${{ inputs.notify_slack && always() && needs.deploy.result == 'failure' }}
+      uses: ./.github/workflows/notify-slack-deployment-failed.yml
+      with:
+        app_name: ${{ inputs.app_name }}
+        env_name: ${{ inputs.environment }}
+        github_username: ${{ github.actor }}
+        workflow_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        compare_url: ${{ github.event_name == 'push' && github.event.compare || null }}
+      secrets:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
+  


### PR DESCRIPTION
### Change description
As per Jira ticket [FS-4946](https://mhclgdigital.atlassian.net/browse/FS-4946) we had run into issues with this repo where an older pipeline had been run against the UAT environment after more recent changes had been deployed, essentially reverting those changes as they did not feature in the older built image.

In the pre-award and data-store workflows we have avoided this issue by setting concurrency groups on the deploy jobs, and also then using a matrix strategy in the called workflow to run deployments in parallel. Any 'pending' jobs that haven't been approved are automatically cancelled by newer jobs with the same concurrency group (see [GitHub actions docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#using-concurrency-in-different-scenarios)).

The production deploy job still uses the shared 'standard deploy' workflow as it only deploys the form runner, but once the form designer is in production this can be updated to use the new matrix workflow.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")
