### PR TITLE
Hotfix/clientsidefileupload fix

### DIFF
--- a/designer/client/components/component-edit/ClientSideFileUploadFieldEdit.tsx
+++ b/designer/client/components/component-edit/ClientSideFileUploadFieldEdit.tsx
@@ -35,11 +35,11 @@ export const ClientSideFileUploadFieldEdit: any = ({context = AdapterComponentCo
         options: {
             dropzoneConfig: {
                 //@ts-ignore
-                maxFiles: selectedComponent.options.dropzoneConfig.maxFiles ? selectedComponent.options.dropzoneConfig.maxFiles : 0,
+                maxFiles: selectedComponent.options.dropzoneConfig.maxFiles ? selectedComponent.options.dropzoneConfig.maxFiles : 1,
                 //@ts-ignore
-                parallelUploads: selectedComponent.options.dropzoneConfig.parallelUploads ? selectedComponent.options.dropzoneConfig.parallelUploads : 0,
+                parallelUploads: selectedComponent.options.dropzoneConfig.parallelUploads ? selectedComponent.options.dropzoneConfig.parallelUploads : 1,
                 //@ts-ignore
-                maxFilesize: selectedComponent.options.dropzoneConfig.maxFilesize ? selectedComponent.options.dropzoneConfig.maxFilesize : 0,
+                maxFilesize: selectedComponent.options.dropzoneConfig.maxFilesize ? selectedComponent.options.dropzoneConfig.maxFilesize : 1,
                 //@ts-ignore
                 acceptedFiles: selectedComponent.options.dropzoneConfig.acceptedFiles
                 //@ts-ignore

--- a/designer/client/components/component-edit/ClientSideFileUploadFieldEdit.tsx
+++ b/designer/client/components/component-edit/ClientSideFileUploadFieldEdit.tsx
@@ -39,11 +39,13 @@ export const ClientSideFileUploadFieldEdit: any = ({context = AdapterComponentCo
                 //@ts-ignore
                 parallelUploads: selectedComponent.options.dropzoneConfig.parallelUploads ? selectedComponent.options.dropzoneConfig.parallelUploads : 0,
                 //@ts-ignore
-                maxFilesize: selectedComponent.options.dropzoneConfig.parallelUploads ? selectedComponent.options.dropzoneConfig.parallelUploads : 0,
+                maxFilesize: selectedComponent.options.dropzoneConfig.maxFilesize ? selectedComponent.options.dropzoneConfig.maxFilesize : 0,
                 //@ts-ignore
                 acceptedFiles: selectedComponent.options.dropzoneConfig.acceptedFiles
+                //@ts-ignore
+                && selectedComponent.options.dropzoneConfig.acceptedFiles.length > 0 ? Array.isArray(selectedComponent.options.dropzoneConfig.acceptedFiles) ?
                     //@ts-ignore
-                && selectedComponent.options.dropzoneConfig.acceptedFiles.length > 0 ? selectedComponent.options.dropzoneConfig.acceptedFiles.split(",") : []
+                    selectedComponent.options.dropzoneConfig.acceptedFiles : selectedComponent.options.dropzoneConfig.acceptedFiles.split(",") : []
             }
         },
         //@ts-ignore
@@ -135,20 +137,23 @@ export const ClientSideFileUploadFieldEdit: any = ({context = AdapterComponentCo
     // Handle change in checkbox selection
     const handleCheckboxChange = (e) => {
         const item = e.target.value;
-        setComponent(
-            {
-                ...component,
-                options: {
-                    ...component.options,
-                    dropzoneConfig: {
-                        ...component.options.dropzoneConfig,
-                        acceptedFiles: [...component.options.dropzoneConfig.acceptedFiles, item]
-                    }
+        const isItemSelected = component.options.dropzoneConfig.acceptedFiles.includes(item);
+        // Create new array - either add or remove item
+        const updatedAcceptedFiles = isItemSelected
+            ? component.options.dropzoneConfig.acceptedFiles.filter(file => file !== item)
+            : [...component.options.dropzoneConfig.acceptedFiles, item];
+        setComponent({
+            ...component,
+            options: {
+                ...component.options,
+                dropzoneConfig: {
+                    ...component.options.dropzoneConfig,
+                    acceptedFiles: updatedAcceptedFiles
                 }
             }
-        )
+        });
         //@ts-ignore
-        selectedComponent.options.dropzoneConfig.acceptedFiles = component.options.dropzoneConfig.acceptedFiles.join(",")
+        selectedComponent.options.dropzoneConfig.acceptedFiles = updatedAcceptedFiles.join(",");
     };
 
     return (


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-5051**


### Change description

1. I have added some default values from designer side for the client side file upload and following are the default values 

```
maxFiles -> 0 previously now 1
parallelUploads -> 0 previously now 1
maxFilesize -> 0 previously now 1
```
for the client side file upload we use dropzone dependency so it required to have these values at least 1 so added these values 

2. When we try to update file types in the client side file upload it was not preserving the state & with this PR we have fixed it 

3. For `maxFilesize` we were using  `parallelUploads` & changed it to correct value which means `maxFilesize`

5. Removed white screen error when try to edit any field this happened when we tried to handle `acceptedFilesa`

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
We have deployed the changes into [dev environment ](https://form-designer.access-funding.dev.communities.gov.uk/app) and try to add a client side file upload & do the above configuration changes then it should allow you to upload file but need to add following query parameter to test wether it is uploading the file or not `?form_session_identifier=dfdskjfs`


### Screenshots of UI changes (if applicable)
