### PR TITLE
Confirm GPL license for tinymce

### DIFF
--- a/runner/src/server/plugins/engine/views/components/freetextfield.html
+++ b/runner/src/server/plugins/engine/views/components/freetextfield.html
@@ -3,6 +3,7 @@
     <head>
         <script type="text/javascript">
             tinymce.init({
+                license_key: 'gpl',
                 help_accessibility: false,
                 setup: function (editor) {
                     editor.on('init input setcontent change', function () {


### PR DESCRIPTION
We see this warning in the browser console for tinymce because we haven't confirmed our license type:

TinyMCE is running in evaluation mode. Provide a valid license key or add license_key: 'gpl' to the init config to agree to the open source license terms.