### PR TITLE
Flip trace sampling rate

### DIFF
--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -52,7 +52,7 @@ network:
 # Pass environment variables as key value pairs.
 variables:
   SENTRY_DSN: "https://6724d8df633d3f4599fbd4cf9c537e3c@o1432034.ingest.us.sentry.io/4508573162864640"
-  SENTRY_TRACES_SAMPLE_RATE: 1.0
+  SENTRY_TRACES_SAMPLE_RATE: 0.02
   ACCESSIBILITY_STATEMENT_URL: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk/accessibility_statement"
   SENTRY_ENV: ${COPILOT_ENVIRONMENT_NAME}
   AWS_BUCKET_NAME:
@@ -141,7 +141,7 @@ environments:
       PRIVACY_POLICY_URL: "https://frontend.access-funding.levellingup.gov.uk/privacy"
       SERVICE_START_PAGE: "https://frontend.access-funding.levellingup.gov.uk/account"
       ELIGIBILITY_RESULT_URL: "https://frontend.access-funding.levellingup.gov.uk/eligibility-result"
-      SENTRY_TRACES_SAMPLE_RATE: 0.02
+      SENTRY_TRACES_SAMPLE_RATE: 1
     count:
       range: 2-4
       cooldown:


### PR DESCRIPTION
Form runner is an extremely noisy application in terms of spans, and it's using the bulk of our tracing allowance in Sentry, which is exhausting our monitoring for other apps.

Until we can 1) refine the logs+metrics from form runner, and 2) increase our sentry quotas, this should bring the volume of form-runner spans down.

I don't think anyone is really using the span insights from dev/test/uat, so we can probably instead focus on generating spans from prod which might help debug live issues. Volume in prod is also far lower because we do not run any automated e2e tests, and our user base is low volume.

form-runner across all envs has emitted about ~5m spans in the last 30 days, compared to ~1.5m from everything else combined.