### PR TITLE
FS-5054 - Hyperlink the Form Designer text in the app header

### DIFF
--- a/designer/server/views/head.html
+++ b/designer/server/views/head.html
@@ -13,7 +13,7 @@
         </div>
             <div class="govuk-header__content">
                 <form method="post" action="/logout">
-                    <span class="govuk-header__service-name"><span class="govuk-header__link">Form Designer</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    <span class="govuk-header__service-name"><a href="/app" class="govuk-header__link">Form Designer</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                         {% if authEnable and not ssoLoginUrl %}
                             <button type="submit" class="govuk-header__link signout_button">Sign out</button>
                         {% endif %}


### PR DESCRIPTION
### Ticket

[Form Designer text in header not hyperlinked](https://mhclgdigital.atlassian.net/browse/FS-5054)

### Description

Converts the "Form Designer" text in the app header from a non-functional span to an actual link directing to the `/app` path. Users can now easily return to the main application dashboard by clicking on the header title. This behaviour is consistent with the FAB header.