### PR TITLE
FS-5058 - Client-side file upload component symbol change

### DIFF
--- a/designer/client/components/AdapterComponent.tsx
+++ b/designer/client/components/AdapterComponent.tsx
@@ -39,7 +39,9 @@ function MultiInputField() {
 function ClientSideFileUploadField() {
     return (
         <ComponentField>
-            <span className="box tall thick-top-border"/>
+            <div className="govuk-!-margin-bottom-1">
+                {"🗂"} <span className="line short" />
+            </div>
         </ComponentField>
     );
 }


### PR DESCRIPTION
### Ticket

[Use appropriate symbol for client-side file upload component in Designer](https://mhclgdigital.atlassian.net/browse/FS-5058)

### Description

This changes how the client-side file upload component is rendered in the Form Designer UI, distinguishing it from other components like text fields. We reuse the same symbol used by the FileUpload component in the base repo.

### Screenshot of UI changes

![image](https://github.com/user-attachments/assets/b1bc2d58-6cfb-450d-a9ef-e27bbde6a64e)
