### PR TITLE
FS-5060 - Makes the 'File upload' component unavailable in Designer

### DIFF
--- a/designer/client/components/component-create/AdapterComponentCreateList.tsx
+++ b/designer/client/components/component-create/AdapterComponentCreateList.tsx
@@ -15,6 +15,11 @@ const selectionFields: AdapterComponentDef[] = [];
 const inputFields: AdapterComponentDef[] = [];
 
 sortBy(AdapterComponentTypes, ["type"]).forEach((component) => {
+    // Skip the FileUpload component entirely
+    if (component.type === "FileUploadField") {
+        return;
+    }
+
     if (component.subType === "content") {
         contentFields.push(component);
     } else if (SelectionFieldsTypes.indexOf(component.type) > -1) {


### PR DESCRIPTION
### Ticket

[Remove "File upload" (server-side) component from Designer](https://mhclgdigital.atlassian.net/browse/FS-5060)

### Description

This component does not work, apparently. And we don't need it to either, as we use client-side file upload these days. This commit prevents it being listed as one of the available component types when you create a new component in the Designer.

### Screenshots of UI changes

![Screenshot 2025-03-18 at 18 03 55](https://github.com/user-attachments/assets/067f5d43-ffae-459d-a219-ddfe1148d8d1)