### PR TITLE
Replacing the incorrect xgovforms schema for this field with the new schema  

### DIFF
--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -5,7 +5,7 @@ import {AdapterFormModel} from "../models";
 import {MultilineTextFieldComponent} from "@xgovformbuilder/model";
 import Joi from "joi";
 
-function inputIsOverWordCount(input, maxWords) {
+function wordCountIsOverMaxWords(input, maxWords) {
     const wordCount = input.match(/\S+/g).length || 0;
     return wordCount > maxWords;
 }
@@ -29,7 +29,7 @@ export class MultilineTextField extends XGovMultilineTextField {
 
         if (maxWords ?? false) {
             this.formSchema = this.formSchema.custom((value, helpers) => {
-                if (inputIsOverWordCount(value, maxWords)) {
+                if (wordCountIsOverMaxWords(value, maxWords)) {
                     return helpers.error("string.maxWords", {limit: maxWords});
                 }
                 return value;

--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -1,0 +1,46 @@
+import {
+    MultilineTextField as XGovMultilineTextField
+} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components";
+import {AdapterFormModel} from "../models";
+import {MultilineTextFieldComponent} from "@xgovformbuilder/model";
+import Joi from "joi";
+
+function inputIsOverWordCount(input, maxWords) {
+    const wordCount = input.match(/\S+/g).length || 0;
+    return wordCount > maxWords;
+}
+
+export class MultilineTextField extends XGovMultilineTextField {
+    constructor(def: MultilineTextFieldComponent, model: AdapterFormModel) {
+        super(def, model);
+        this.options = def.options;
+        this.schema = def.schema;
+        this.formSchema = Joi.string();
+        this.formSchema = this.formSchema.label(def.title);
+        const {maxWords, customValidationMessage} = def.options;
+        const isRequired = def.options.required ?? true;
+
+        if (isRequired) {
+            this.formSchema = this.formSchema.required();
+        } else {
+            this.formSchema = this.formSchema.allow("").allow(null);
+        }
+        this.formSchema = this.formSchema.ruleset;
+
+        if (maxWords ?? false) {
+            this.formSchema = this.formSchema.custom((value, helpers) => {
+                if (inputIsOverWordCount(value, maxWords)) {
+                    return helpers.error("string.maxWords", {limit: maxWords});
+                }
+                return value;
+            }, "max words validation");
+            this.isCharacterOrWordCount = true;
+        }
+
+        if (customValidationMessage) {
+            this.formSchema = this.formSchema.rule({
+                message: customValidationMessage,
+            });
+        }
+    }
+}

--- a/runner/src/server/plugins/engine/components/index.ts
+++ b/runner/src/server/plugins/engine/components/index.ts
@@ -36,9 +36,7 @@ export {
 export {Html} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/Html";
 export {InsetText} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/InsetText";
 export {List} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/List";
-export {
-    MultilineTextField
-} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/MultilineTextField";
+export {MultilineTextField} from "./MultilineTextField"
 export {
     NumberField
 } from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/NumberField";

--- a/runner/test/cases/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/MultilineTextField.test.ts
@@ -1,0 +1,89 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+// @ts-ignore
+import {MultilineTextField} from "src/server/plugins/engine/components";
+// @ts-ignore
+import {AdapterFormModel} from "src/server/plugins/engine/models";
+// @ts-ignore
+import {FormSubmissionState, FormPayload} from "src/server/plugins/engine/types";
+// @ts-ignore
+import {TranslationLoaderService} from "src/server/services/TranslationLoaderService";
+
+const lab = Lab.script();
+exports.lab = lab;
+const {expect} = Code;
+const {beforeEach, suite, test} = lab;
+
+suite("MultilineTextField", () => {
+    let model: AdapterFormModel;
+    let componentDefinition: MultilineTextField;
+
+    beforeEach(() => {
+        const translationService: TranslationLoaderService = new TranslationLoaderService();
+        const translations = translationService.getTranslations();
+        model = {
+            def: {
+                metadata: {}
+            },
+            options: {
+                translationEn: translations.en,
+                translationCy: translations.cy
+            }
+        } as AdapterFormModel;
+
+        componentDefinition = {
+            type: "MultilineTextField",
+            name: "multiLineText",
+            options: {
+                required: true,
+                maxWords: 100,
+                customValidationMessage: "Too many words!"
+            },
+            schema: {},
+            title: "Multiline Text Field"
+        };
+    });
+
+    test("should create form schema with correct structure", () => {
+        const multiLineTextField = new MultilineTextField(componentDefinition, model);
+
+        expect(multiLineTextField.formSchema).to.exist();
+        expect(multiLineTextField.formSchema.type).to.equal('string');
+    });
+
+    test("getFormSchemaKeys should return form schema keys", () => {
+        const multiLineTextField = new MultilineTextField(componentDefinition, model);
+        const schemaKeys = multiLineTextField.getFormSchemaKeys();
+
+        expect(schemaKeys).to.be.an.object();
+        expect(schemaKeys.multiLineText).to.exist();
+    });
+
+    test("getStateSchemaKeys should return state schema keys", () => {
+        const multiLineTextField = new MultilineTextField(componentDefinition, model);
+        const stateSchemaKeys = multiLineTextField.getStateSchemaKeys();
+
+        expect(stateSchemaKeys).to.be.an.object();
+        expect(stateSchemaKeys.multiLineText).to.exist();
+    });
+
+    test("getFormDataFromState should return form data from state", () => {
+        const multiLineTextField = new MultilineTextField(componentDefinition, model);
+        const state: FormSubmissionState = {multiLineText: "sample text"};
+        const formData = multiLineTextField.getFormDataFromState(state);
+
+        expect(formData).to.be.an.object();
+        expect(formData.multiLineText).to.equal("sample text");
+    });
+
+    test("getViewModel should return view model from form data and errors", () => {
+        const multiLineTextField = new MultilineTextField(componentDefinition, model);
+        const formData = {multiLineText: "sample text"};
+        const errors = {};
+        const viewModel = multiLineTextField.getViewModel(formData, errors);
+
+        expect(viewModel).to.be.an.object();
+        expect(viewModel.isCharacterOrWordCount).to.be.true();
+        expect(viewModel.maxwords).to.equal(100);
+    });
+});


### PR DESCRIPTION
**Ticket:https://mhclgdigital.atlassian.net/browse/FS-5055**

### Change description
When I am checking the schema validation that they are using to validate maxWord count is totally wrong So I had to replace the logic into correct one 

Following is the way they have checked the max word count but  we should have `maxWords > wordCount;`
```
function inputIsOverWordCount(input, maxWords) {
  /**
   * This validation is copied from the govuk-frontend library to match their client side behaviour
   * the {@link https://github.com/alphagov/govuk-frontend/blob/e1612b13771fb7ca9a58ee85393aec94a1849335/src/govuk/components/character-count/character-count.js#L91 | govuk-frontend} library
   */
  const wordCount = input.match(/\S+/g).length || 0;
  return maxWords > wordCount;
}
```

- [x] Unit tests and other appropriate tests added or updated
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Create a Multiline input field via designer put max word count & preview and add more than desired word count should not allow the user to proceed 
