### PR TITLE
Adding form session identifier to mimic the file upload behaviour in the dev test and uat

### DIFF
--- a/designer/client/components/Page/AdapterPage.tsx
+++ b/designer/client/components/Page/AdapterPage.tsx
@@ -14,7 +14,7 @@ import {AdapterDataContext} from "../../context/AdapterDataContext";
 import {AdapterComponentContextProvider} from "../../reducers/component/AdapterComponentReducer";
 import AdapterComponentCreate from "../component-create/AdapterComponentCreate";
 import {AdapterPageEdit} from "../component-edit/AdapterPageEdit";
-
+import {v4 as uuidv4} from 'uuid';
 
 const SortableItem = SortableElement(({index, page, component, data}) => (
     <div className="component-item">
@@ -174,7 +174,8 @@ export const AdapterPage = ({page, previewUrl, id, layout}) => {
         if (isMultiInputUpdated) {
             await save(data);
         }
-        const url = new URL(`${id}${page.path}`, previewUrl).toString();
+
+        const url = new URL(`${id}${page.path}?form_session_identifier=preview/${uuidv4()}`, previewUrl).toString();
         // Check if Cypress is running because in cypress it will not detect the new tabs created by the window.open,
         // and it will be a separate browser context for that so to avoid that using this check
         //@ts-ignore


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FS-5059**

### Change description
When the user creating the forms with client side file upload it needs to actually upload a file if it is a mandatory field to go beyond that page so here we have added a session identification to upload the file into S3 and it uses a prefix of `preview/uuid` 

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

### How to test
In designer create a form add a client side file upload you should see that it is uploading in the preview mode since it has the `form_session_identifier`
