### PR TITLE
Show preview mode on the forms if coming from designer or fab

### DIFF
--- a/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
@@ -544,6 +544,24 @@ export class PageControllerBase {
         return relevantState;
     }
 
+    protected async handlePreviewMode(request: HapiRequest, viewModel: any): Promise<void> {
+        const {adapterCacheService} = request.services([]);
+        const {form_session_identifier} = request.query;
+        
+        if (form_session_identifier && form_session_identifier.includes("preview")) {
+            //@ts-ignore
+            await adapterCacheService.mergeState(request, {
+                "previewMode": true,
+            });
+            //@ts-ignore
+            viewModel.previewMode = true;
+            viewModel.backLinkText = "";
+            this.backLinkText = "";
+            viewModel.backLink = "";
+            this.backLink = "";
+        }
+    }
+
     makeGetRouteHandler() {
         return async (request: HapiRequest, h: HapiResponseToolkit) => {
             const {adapterCacheService} = request.services([]);
@@ -691,19 +709,7 @@ export class PageControllerBase {
             }
 
             // handling preview mode
-            const {form_session_identifier} = request.query;
-            if (form_session_identifier && form_session_identifier.includes("preview")) {
-                //@ts-ignore
-                await adapterCacheService.mergeState(request, {
-                    "previewMode": true,
-                });
-                //@ts-ignore
-                viewModel.previewMode = true;
-                viewModel.backLinkText = ""
-                this.backLinkText = ""
-                viewModel.backLink = ""
-                this.backLink = ""
-            }
+            await this.handlePreviewMode(request, viewModel);
 
             return h.view(this.viewName, viewModel);
         };

--- a/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
@@ -689,6 +689,22 @@ export class PageControllerBase {
                     }
                 }
             }
+
+            // handling preview mode
+            const {form_session_identifier} = request.query;
+            if (form_session_identifier && form_session_identifier.includes("preview")) {
+                //@ts-ignore
+                await adapterCacheService.mergeState(request, {
+                    "previewMode": true,
+                });
+                //@ts-ignore
+                viewModel.previewMode = true;
+                viewModel.backLinkText = ""
+                this.backLinkText = ""
+                viewModel.backLink = ""
+                this.backLink = ""
+            }
+
             return h.view(this.viewName, viewModel);
         };
     }

--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -63,6 +63,9 @@ export class SummaryPageController extends PageController {
             }
             //@ts-ignore
             const viewModel = new AdapterSummaryViewModel(this.title, model, state, request, this);
+            
+            await this.handlePreviewMode(request, viewModel);
+            
             if (viewModel.endPage) {
                 return redirectTo(request, h, `/${model.basePath}${viewModel.endPage.path}`);
             }

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -183,7 +183,7 @@
         {% endif %}
     {% endif %}
 
-    {% if page.backLink or backLink%}
+    {% if page.backLink or backLink %}
         {% if page.backLink %}
             {{ govukBackLink({
                 href: page.backLink,

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -5,6 +5,7 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "skip-link/macro.njk" import govukSkipLink -%}
 {% from "./partials/change-requests-banner.html" import changeRequestsBanner %}
+{% from "./partials/preview-banner.html" import previewBanner %}
 
 
 {% block head %}
@@ -181,16 +182,19 @@
             }) }}
         {% endif %}
     {% endif %}
-    {% if page.backLink %}
-        {{ govukBackLink({
-            href: page.backLink,
-            text: page.backLinkText
-        }) }}
-    {% else %}
-        {{ govukBackLink({
-            href: backLink,
-            text: backLinkText
-        }) }}
+
+    {% if page.backLink or backLink%}
+        {% if page.backLink %}
+            {{ govukBackLink({
+                href: page.backLink,
+                text: page.backLinkText
+            }) }}
+        {% else %}
+            {{ govukBackLink({
+                href: backLink,
+                text: backLinkText
+            }) }}
+        {% endif %}
     {% endif %}
 
     {% if changeRequests.length > 0 %}
@@ -203,6 +207,11 @@
             </p>
         </div>
     {% endif %}
+
+    {% if previewMode %}
+        {{ previewBanner() }}
+    {% endif %}
+
 {% endblock %}
 
 

--- a/runner/src/server/views/partials/preview-banner.html
+++ b/runner/src/server/views/partials/preview-banner.html
@@ -1,0 +1,15 @@
+{% macro previewBanner() %}
+<div class="govuk-!-margin-top-4">
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+         data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Important
+            </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+            This is a preview of your application form. You cannot enter any answers.
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/runner/src/server/views/partials/preview-banner.html
+++ b/runner/src/server/views/partials/preview-banner.html
@@ -1,6 +1,6 @@
 {% macro previewBanner() %}
 <div class="govuk-!-margin-top-4">
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+    <div class="govuk-notification-banner govuk-!-margin-bottom-0" role="region" aria-labelledby="govuk-notification-banner-title"
          data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
             <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
@@ -8,7 +8,7 @@
             </h2>
         </div>
         <div class="govuk-notification-banner__content">
-            This is a preview of your application form. You cannot enter any answers.
+            This is a preview of your application form.
         </div>
     </div>
 </div>

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -12,6 +12,9 @@
         },
         html: i18nGetTranslation("head.banner.title")
     }) }}
+    {% if previewMode %}
+        {{ previewBanner() }}
+    {% endif %}
     {% if page.isEligibility or isReadOnlySummary %}
         {{ govukBackLink({
             href: backLink or page.backLink,


### PR DESCRIPTION
## Ticket: 

[Don't show "Go back to application overview" in Form Runner previews](https://mhclgdigital.atlassian.net/browse/FS-5023) , 

[Add a banner for preview mode to notify users that no data is saved during testing (Manage Application Configuration)](https://mhclgdigital.atlassian.net/browse/FS-4852)



### Change description
When user opens the form through FAB or designer it should show the user that we are not saving any data so here in the parameter we send https://form-runner.levellingup.gov.localhost:3009/about-your-organisation/before-you-start?form_session_identifier=preview/ed595f07-b37d-4485-b264-819d400d9937 here we have preview so this is preview mode that we are going to use and based on that we show the banner in the runner 

### How to test
Open a form from FAB or form designer also verified the changes with the apply process (no impact in this)


### Screenshots of UI changes (if applicable)
![image](https://github.com/user-attachments/assets/0a0fa8e3-6580-4cbf-8ca0-793b61ac1d9e)
