### PR TITLE
Fixing issue whereby user errors lead to response.header is not a function TypeError

### DIFF
--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -149,14 +149,14 @@ async function createServer(routeConfig: RouteConfig) {
         (request: HapiRequest, h: HapiResponseToolkit) => {
             const {response} = request;
 
-            if ("isBoom" in response && response.isBoom
-                && response?.output?.statusCode >= 500
-                && response?.output?.statusCode < 600) {
-                Sentry.captureException(response);
+            if ("isBoom" in response && response.isBoom) {
+                if (response.output.statusCode >= 500 && response.output.statusCode < 600) {
+                    Sentry.captureException(response);
+                }
                 return h.continue;
             }
 
-            if ("header" in response && response.header) {
+            if ("header" in response && typeof response.header === "function") {
                 response.header("X-Robots-Tag", "noindex, nofollow");
 
                 const existingHeaders = response.headers;


### PR DESCRIPTION
Relates to Sentry error: https://funding-service-design-team-dl.sentry.io/issues/6471426578/?alert_rule_id=15706220&alert_type=issue&notification_uuid=08b61e1e-1e35-4fac-bad5-01612c95b829&project=4508573162864640&referrer=slack

The server crashes (TypeError: response.header is not a function) when onPreResponse tries modifying headers on non-5xx Boom error objects (e.g., 404s).

This PR changes onPreResponse in index.ts to bypass header modifications for all Boom errors (response.isBoom), preventing calls to the non-existent .header() function on those error objects (see [docs](https://hapi.dev/module/boom/api/?v=10.0.1)). This aligns with the code in the [base repo's `index.ts`](https://github.com/xgovformbuilder/digital-form-builder/blob/95b1d6da06a8b98b097b84fdaa0748440aae9892/runner/src/server/index.ts.) which also bypasses header modifications in the case of Boom objects.