### PR TITLE
Allow pdfs file uploads

### DIFF
--- a/fsd_config/form_jsons/cfa_r1/cfa-r1-your-project.json
+++ b/fsd_config/form_jsons/cfa_r1/cfa-r1-your-project.json
@@ -130,7 +130,7 @@
               "maxFiles": 1,
               "parallelUploads": 1,
               "maxFilesize": 10,
-              "acceptedFiles": "application/vnd.oasis.opendocument.spreadsheet,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv"
+              "acceptedFiles": "application/vnd.oasis.opendocument.spreadsheet,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv,application/pdf"
             },
             "hideTitle": true,
             "minimumRequiredFiles": 1


### PR DESCRIPTION
Allow the Delivery plan to be pdf too.

Now it only allows spreadsheets.