### PR TITLE
Update default templates, and extra log

### DIFF
--- a/e2e-test/cypress/e2e/runner/completeAForm.feature
+++ b/e2e-test/cypress/e2e/runner/completeAForm.feature
@@ -20,7 +20,7 @@ Feature: Complete a form
       | Do you have any evidence?           | No, I don't have evidence |
       | Additional Info                     | the additional info       |
     When I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 
 
   Scenario: Testing condition - User does not have a link
@@ -87,7 +87,7 @@ Feature: Complete a form
     * I enter "jen+forms@cautionyourblast.com" for "Your email address"
     * I continue
     * I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 
 
   Scenario: Error messages are displayed and can be resolved

--- a/e2e-test/cypress/e2e/runner/freeTextfield.feature
+++ b/e2e-test/cypress/e2e/runner/freeTextfield.feature
@@ -26,7 +26,7 @@ Feature: Rich Text Field
       | title                       | value                      |
       | Free Text Field test max 10 | this is an free text field |
     When I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 
   Scenario: Testing if free text field is non optional and adding formatted text
     And I navigate to the "free-text-field" form
@@ -37,5 +37,5 @@ Feature: Rich Text Field
       | title                       | value                                   |
       | Free Text Field test max 10 | <ul><li>item 1</li><li>item 2</li></ul> |
     When I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 

--- a/runner/src/server/plugins/engine/api/RegisterApplicationStatusApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterApplicationStatusApi.ts
@@ -36,6 +36,7 @@ export class RegisterApplicationStatusApi implements RegisterApi {
                         return h.redirect(state.metadata.round_close_notification_url);
                     }
 
+                    // a session will always have a callback
                     if (state.callback?.skipSummary?.redirectUrl || state.callback?.returnUrl) {
                         let redirectUrl = state.callback?.skipSummary?.redirectUrl;
                         if (redirectUrl == undefined && state.callback?.returnUrl != undefined) {
@@ -52,12 +53,19 @@ export class RegisterApplicationStatusApi implements RegisterApi {
                         return h.redirect(redirectUrl);
                     }
 
+                    // if you are here the session likely dropped
+                    // or you are previewing the form
+                    request.logger.info(
+                        ["applicationStatus"],
+                        `Showing confirmation page ${request.yar.id} - session likely dropped`
+                    );
+
                     const viewModel = adapterStatusService.getViewModel(state, form, newReference);
                     //@ts-ignore
                     await adapterCacheService.setConfirmationState(request, {confirmation: viewModel,});
                     //@ts-ignore
                     await adapterCacheService.clearState(request);
-                    return h.view("confirmation", viewModel);
+                    return h.view("500", viewModel);
                 },
             },
         });

--- a/runner/src/server/views/500.html
+++ b/runner/src/server/views/500.html
@@ -1,0 +1,23 @@
+{% set mainClasses = "govuk-main-wrapper--l" %}
+{% set skipTimeoutWarning = true %}
+{% extends 'layout.html' %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <p class="govuk-body">
+        Contact us through our <a class="govuk-link" href="https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5/group/68" target="_blank">support desk</a> if you need help.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -1,0 +1,1 @@
+{% extends '500.html' %}


### PR DESCRIPTION
Change 500 and confirmation templates.

It's hard to prove that the confirmation template is no longer used by the digital-from-builder, but to assure that the fake APPLICATION COMPLETE page does not show up again, we override it and make it show the same message as the 500 page.

The journey that likely showed the confirmation template was replaced to show the 500 template instead.

Updating the e2e tests, as they are checking for the APPLICATION COMPLETE heading that we never care to show to our users.

## How to test?

- Edit `runner/config/default.js` make the `sessionTimeout` to be `5000` -> this will make the session expire quickly
- Edit `runner/src/server/views/layout.html` delete the line `<script src="{{ assetPath }}/modal-dialog.js"></script>` -> this will prevent the modal to pop-up

- Now `make pre up` and go to a form and wait 5 seconds. 
- After 5 seconds your session will die and after you Save and continue on the summary page you will hit the 500 template. 
- Application Complete page is no more.