### PR TITLE
Break journey if session expires

### DIFF
--- a/e2e-test/cypress/e2e/runner/completeAForm.feature
+++ b/e2e-test/cypress/e2e/runner/completeAForm.feature
@@ -20,7 +20,7 @@ Feature: Complete a form
       | Do you have any evidence?           | No, I don't have evidence |
       | Additional Info                     | the additional info       |
     When I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 
 
   Scenario: Testing condition - User does not have a link
@@ -87,7 +87,7 @@ Feature: Complete a form
     * I enter "jen+forms@cautionyourblast.com" for "Your email address"
     * I continue
     * I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 
 
   Scenario: Error messages are displayed and can be resolved

--- a/e2e-test/cypress/e2e/runner/freeTextfield.feature
+++ b/e2e-test/cypress/e2e/runner/freeTextfield.feature
@@ -26,7 +26,7 @@ Feature: Rich Text Field
       | title                       | value                      |
       | Free Text Field test max 10 | this is an free text field |
     When I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 
   Scenario: Testing if free text field is non optional and adding formatted text
     And I navigate to the "free-text-field" form
@@ -37,5 +37,5 @@ Feature: Rich Text Field
       | title                       | value                                   |
       | Free Text Field test max 10 | <ul><li>item 1</li><li>item 2</li></ul> |
     When I submit the form adapter
-    Then I see "Application complete"
+    Then I don't see "Application complete"
 

--- a/runner/src/server/plugins/engine/api/RegisterApplicationStatusApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterApplicationStatusApi.ts
@@ -36,6 +36,7 @@ export class RegisterApplicationStatusApi implements RegisterApi {
                         return h.redirect(state.metadata.round_close_notification_url);
                     }
 
+                    // a session will always have a callback
                     if (state.callback?.skipSummary?.redirectUrl || state.callback?.returnUrl) {
                         let redirectUrl = state.callback?.skipSummary?.redirectUrl;
                         if (redirectUrl == undefined && state.callback?.returnUrl != undefined) {
@@ -52,12 +53,19 @@ export class RegisterApplicationStatusApi implements RegisterApi {
                         return h.redirect(redirectUrl);
                     }
 
+                    // if you are here the session likely dropped
+                    // or you are previewing the form
+                    request.logger.info(
+                        ["applicationStatus"],
+                        `Showing confirmation page ${request.yar.id} - session likely dropped`
+                    );
+
                     const viewModel = adapterStatusService.getViewModel(state, form, newReference);
                     //@ts-ignore
                     await adapterCacheService.setConfirmationState(request, {confirmation: viewModel,});
                     //@ts-ignore
                     await adapterCacheService.clearState(request);
-                    return h.view("confirmation", viewModel);
+                    return h.view("500", viewModel);
                 },
             },
         });

--- a/runner/src/server/views/500.html
+++ b/runner/src/server/views/500.html
@@ -1,0 +1,23 @@
+{% set mainClasses = "govuk-main-wrapper--l" %}
+{% set skipTimeoutWarning = true %}
+{% extends 'layout.html' %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+      <p class="govuk-body">
+        Contact us through our <a class="govuk-link" href="https://mhclgdigital.atlassian.net/servicedesk/customer/portal/5/group/68" target="_blank">support desk</a> if you need help.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -1,0 +1,1 @@
+{% extends '500.html' %}

--- a/runner/test/cases/server/plugins/engine/page-controllers/ContinuePageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/ContinuePageController.test.ts
@@ -6,6 +6,7 @@ import createServer from "src/server";
 import cheerio from "cheerio";
 //@ts-ignore
 import {config} from "../../../../../../src/server/plugins/utils/AdapterConfigurationSchema";
+import * as sinon from "sinon";
 
 const {expect} = Code;
 const lab = Lab.script();
@@ -15,6 +16,7 @@ const {suite, test, before, after} = lab;
 suite("ContinuePageController", () => {
     let server;
     let $;
+    let adapterCacheService;
 
     before(async () => {
         config.jwtAuthEnabled = false;
@@ -23,6 +25,10 @@ suite("ContinuePageController", () => {
             formFilePath: path.join(__dirname, "../../../"),
             enforceCsrf: false,
         });
+        // Create a mock of adapterCacheService
+        adapterCacheService = {
+            getState: sinon.stub()
+        };
     });
 
     after(async () => {
@@ -30,6 +36,18 @@ suite("ContinuePageController", () => {
     });
 
     test("should display continue button with label on page view when continue page controller is loaded", async () => {
+        const { adapterCacheService } = server.services();
+        adapterCacheService.getState = () => {
+            return Promise.resolve({
+                metadata: {
+                    "any": "metadata"
+                },
+                callback: {
+                    "any": "callback"
+                }
+            });
+        };
+
         const response = await server.inject({
             method: 'GET',
             url: '/continue-page.test/are-you-applying-from-a-local-authority-in-england'

--- a/runner/test/cases/server/plugins/engine/page-controllers/DefaultPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/DefaultPageController.test.ts
@@ -59,13 +59,17 @@ suite("DefaultPageController", () => {
     });
 
     test("renders default page with form components", async () => {
-        // Define the mock state with metadata
-        const mockState = {
-            metadata: {}
-            // Add any other necessary metadata here
+        const { adapterCacheService } = server.services();
+        adapterCacheService.getState = () => {
+            return Promise.resolve({
+                metadata: {
+                    "any": "metadata"
+                },
+                callback: {
+                    "any": "callback"
+                }
+            });
         };
-        // Stub getState to return the mock state
-        adapterCacheService.getState.resolves(mockState);
 
         const response = await server.inject({
             method: 'GET',

--- a/runner/test/cases/server/plugins/engine/page-controllers/PageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/PageController.test.ts
@@ -42,13 +42,17 @@ suite("PageController", () => {
     });
 
     test("GET request - renders page correctly", async () => {
-        // Define the mock state with metadata
-        const mockState = {
-            metadata: {}
-            // Add any other necessary metadata here
+        const { adapterCacheService } = server.services();
+        adapterCacheService.getState = () => {
+            return Promise.resolve({
+                metadata: {
+                    "any": "metadata"
+                },
+                callback: {
+                    "any": "callback"
+                }
+            });
         };
-        // Stub getState to return the mock state
-        adapterCacheService.getState.resolves(mockState);
 
         const response = await server.inject({
             method: 'GET',
@@ -108,6 +112,9 @@ suite("PageController", () => {
                     change_requests: {
                         "VcyKVN": ["Assessor Feedback"]
                     }
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };
@@ -136,6 +143,9 @@ suite("PageController", () => {
                     change_requests: {
                         "no_found": ["Assessor Feedback"]
                     }
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };
@@ -165,6 +175,9 @@ suite("PageController", () => {
                         "no_found": ["Assessor Feedback"]
                     },
                     is_resubmission: true
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };
@@ -194,6 +207,9 @@ suite("PageController", () => {
                         "VcyKVN": ["Assessor Feedback"]
                     },
                     is_resubmission: true
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };
@@ -221,6 +237,9 @@ suite("PageController", () => {
                 metadata: {
                     change_requests: {},
                     is_resubmission: false
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };

--- a/runner/test/cases/server/plugins/engine/page-controllers/StartPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/StartPageController.test.ts
@@ -58,13 +58,17 @@ suite("StartPageController", () => {
     });
 
     test("renders start page with form components", async () => {
-        // Define the mock state with metadata
-        const mockState = {
-            metadata: {}
-            // Add any other necessary metadata here
+        const { adapterCacheService } = server.services();
+        adapterCacheService.getState = () => {
+            return Promise.resolve({
+                metadata: {
+                    "any": "metadata"
+                },
+                callback: {
+                    "any": "callback"
+                }
+            });
         };
-        // Stub getState to return the mock state
-        adapterCacheService.getState.resolves(mockState);
 
         const response = await server.inject({
             method: 'GET',
@@ -100,6 +104,9 @@ suite("StartPageController", () => {
                     change_requests: {
                         "VcyKVN": ["Assessor Feedback"]
                     }
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };
@@ -121,6 +128,9 @@ suite("StartPageController", () => {
                     change_requests: {
                         "VcyKVN": ["Assessor Feedback"]
                     }
+                },
+                callback: {
+                    "any": "callback"
                 }
             });
         };


### PR DESCRIPTION
Add middleware to check for a user session, raise 408 error and show the 500 template if session dies

## How to test?

- Edit `runner/config/default.js` make the `sessionTimeout` to be `5000` -> this will make the session expire quickly
- Edit `runner/src/server/views/layout.html` delete the line `<script src="{{ assetPath }}/modal-dialog.js"></script>` -> this will prevent the modal to pop-up

- Now `make pre up` and go to a form and wait 5 seconds. 
- After 5 seconds your session will die and after you Save and continue ~~on the summary page~~ **on any page** you will hit the 500 template. 