### PR TITLE
FLS-1237: exclude health-check from Sentry traces sampler

### DIFF
--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -62,7 +62,7 @@ variables:
   SERVICE_START_PAGE: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/account"
   ELIGIBILITY_RESULT_URL: "https://apply.access-funding.${COPILOT_ENVIRONMENT_NAME}.communities.gov.uk/eligibility-result"
   SENTRY_DSN: "https://6724d8df633d3f4599fbd4cf9c537e3c@o1432034.ingest.us.sentry.io/4508573162864640"
-  SENTRY_TRACES_SAMPLE_RATE: 0.02
+  SENTRY_TRACES_SAMPLE_RATE: 0.002
   COPILOT_ENV: ${COPILOT_ENVIRONMENT_NAME}
   AWS_BUCKET_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
@@ -121,7 +121,7 @@ environments:
       PRIVACY_POLICY_URL: "https://apply.access-funding.communities.gov.uk/privacy"
       SERVICE_START_PAGE: "https://apply.access-funding.communities.gov.uk/account"
       ELIGIBILITY_RESULT_URL: "https://apply.access-funding.communities.gov.uk/eligibility-result"
-      SENTRY_TRACES_SAMPLE_RATE: 1
+      SENTRY_TRACES_SAMPLE_RATE: 0.1
     count:
       range: 2-4
       cooldown:

--- a/runner/src/instrument.ts
+++ b/runner/src/instrument.ts
@@ -4,13 +4,19 @@ import {NodeOptions} from "@sentry/node";
 
 if (config.sentryDsn) {
     const sentryConfig: NodeOptions = {
-        dsn: config.sentryDsn, // Replace with your Sentry DSN
+        dsn: config.sentryDsn,
         environment: config.copilotEnv || "development" // Use the provided environment or default to "development"
     };
-    // Include tracesSampleRate only if it's available
+    // Include tracesSampler only if tracesSamplerRate is available
     if (config.sentryTracesSampleRate) {
-        sentryConfig.tracesSampleRate = Number(config.sentryTracesSampleRate);
+        sentryConfig.tracesSampler = (samplingContext) => {
+			// exclude health-check transactions
+			if (samplingContext.normalizedRequest?.url?.endsWith('/health-check')) {
+				return 0
+			}
+			return Number(config.sentryTracesSampleRate);
+		}
     }
-    console.log(`[SENTRY MONITORING ENABLED] Environment: ${sentryConfig.environment} Sample Rate: ${sentryConfig.tracesSampleRate} DSN Available`);
+    console.log(`[SENTRY MONITORING ENABLED] Environment: ${sentryConfig.environment} Sample Rate: ${config.sentryTracesSampleRate} DSN Available`);
     Sentry.init(sentryConfig);
 }


### PR DESCRIPTION
### Change description
Exclude /health-check from Sentry traces sampler as the internal health check requests are using up our transaction quota.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* set `SENTRY_DSN` and `SENTRY_TRACES_SAMPLE_RATE` in your env
* Add logging in block
* go to `/health-check` route, logging should indicate conditional block being reached

Post-deployment we can check that `/health-check` transactions are no longer being recorded in Sentry
![Screenshot 2025-04-25 at 15 16 01](https://github.com/user-attachments/assets/548d2aba-3e20-410f-9418-9332a0aea9e4)


### Screenshots of UI changes (if applicable)
