### PR TITLE
Generic file label and set hint for file upload component

### DIFF
--- a/runner/locales/cy.json
+++ b/runner/locales/cy.json
@@ -45,6 +45,9 @@
       "description3": "Bydd eich ffeiliau yn dal i gael eu llwytho i fyny pan fyddwch yn taro \"Cadw a pharhau\". Os byddwch yn ailymweld â'r dudalen hon, byddwch yn gallu gweld eich ffeiliau a uwchlwythwyd yn flaenorol.",
       "fileUploadBtn": "Dewiswch ffeil",
       "filesUploadBtn": "Dewiswch ffeiliau",
+      "uploadFileTitle": "Upload file",
+      "formatMustBe": "Format must be",
+      "fileSizeLimitPart": "The selected file must be smaller than",
       "table": {
         "fileNameCol": "Enw'r ffeil",
         "fileSizeCol": "Maint y ffeil",

--- a/runner/locales/en.json
+++ b/runner/locales/en.json
@@ -1,100 +1,103 @@
 {
-  "signOut": "Sign out",
-  "markAsComplete": "Do you want to mark this section as complete ?",
-  "removeText": "Remove",
-  "validation": {
-    "required": "{#label} is required",
-    "max": "{#label} must be {#limit} characters or less",
-    "min": "{#label} must be {#limit} characters or more",
-    "regex": "enter a valid {#label}",
-    "email": "{#label} must be a valid email address",
-    "number": "{#label} must be a number",
-    "numberMin": "{#label} must be {#limit} or higher",
-    "numberMax": "{#label} must be {#limit} or lower",
-    "format": "Enter a valid {#label}",
-    "maxWords": "{#label} must be {#limit} words or fewer",
-    "dateRequired": "{#label} must be a real date",
-    "dateFormat": "{#label} must be a real date",
-    "dateMin": "{#label} must be the same as or after {#limit}",
-    "dateMax": "{#label} must be the same as or before {#limit}",
-    "selectRequired": "{#label} is required",
-    "title1": "There is a problem",
-    "title2": "Fix the following errors",
-    "fileUpload": {
-      "filePartiallyUploadError": "The files have not fully uploaded",
-      "fileUploadSizeError": "File must be under ",
-      "fileUploadCombinedSizeError": "Combined filesize must be under ",
-      "fileUploadTypeError": "You can't upload files of this type.",
-      "fileUploadCountSingleError": "You can only upload a single file",
-      "fileUploadCountMaxError": "You can only upload {maxFiles} files",
-      "fileUploadCountMinError": "{labelText} requires {minimumRequiredFiles} files",
-      "fileUploadSelectedFileMaxError": "The selected file must be smaller than {size}MB"
-    },
-    "ukAddressField": {
-      "invalidPostCodeError": "Enter a valid postcode"
-    },
-    "telephoneNumberField": {
-      "incorrectFormat": "Enter a telephone number in the correct format"
-    }
-  },
-  "components": {
-    "clientSideFileUpload": {
-      "javascriptEnableMessageTitle": "You need to have JavaScript enabled to see your selected files",
-      "description1": "Why is JavaScript required?",
-      "description2": "Without JavaScript, you will be able to select files to upload, but you won't be able to see them on this page.",
-      "description3": "Your files will still be uploaded when you hit \"Save and continue\". If you revisit this page, you will be able to see your previously uploaded files.",
-      "fileUploadBtn": "Choose file",
-      "filesUploadBtn": "Choose files",
-      "table": {
-        "fileNameCol": "File name",
-        "fileSizeCol": "File size",
-        "fileProgressCol": "Progress",
-        "fileActionCol": "Action",
-        "fileActionComplete": "Complete",
-        "fileActionFailed": "Failed",
-        "deleteBtn": "Delete"
-      }
-    },
-    "freeTextField": {
-      "wordCountReminder": "You have {count} words remaining",
-      "wordCountRemainingError": "You have {count} words too many",
-      "wordCountError": "You can enter up to {count} words",
-      "error": "Error:"
-    },
-    "markAsComplete": {
-      "error": "You must select yes or no"
-    },
-    "declaration": {
-      "error": "You must declare to be able to submit this application"
-    },
-    "ukAddressField": {
-      "addressLine1": "Address line 1",
-      "addressLine2": "Address line 2",
-      "townOrCity": "Town or city",
-      "county": "County",
-      "postcode": "Postcode"
-    },
-    "yesOrNoField": {
-      "yes": "Yes",
-      "no": "No"
-    },
-    "changeRequestpage": {
-      "title": "We need you to make changes",
-      "itemOne": "The assessor has asked you to make a change to specific parts of this section.",
-      "itemTwo": "The pages where you need to make a change will be highlighted.",
-      "itemThree": "You do not need to make changes to any other pages."
-    }
-  },
-  "head": {
-    "banner": {
-      "title": "This is a new service.",
-      "tag": "beta"
-    }
-  },
-  "footer": {
-    "privacy": "Privacy",
-    "cookies": "Cookies",
-    "accessibilityStatement": "Accessibility Statement",
-    "contactUs": "Contact Us"
-  }
+	"signOut": "Sign out",
+	"markAsComplete": "Do you want to mark this section as complete ?",
+	"removeText": "Remove",
+	"validation": {
+		"required": "{#label} is required",
+		"max": "{#label} must be {#limit} characters or less",
+		"min": "{#label} must be {#limit} characters or more",
+		"regex": "enter a valid {#label}",
+		"email": "{#label} must be a valid email address",
+		"number": "{#label} must be a number",
+		"numberMin": "{#label} must be {#limit} or higher",
+		"numberMax": "{#label} must be {#limit} or lower",
+		"format": "Enter a valid {#label}",
+		"maxWords": "{#label} must be {#limit} words or fewer",
+		"dateRequired": "{#label} must be a real date",
+		"dateFormat": "{#label} must be a real date",
+		"dateMin": "{#label} must be the same as or after {#limit}",
+		"dateMax": "{#label} must be the same as or before {#limit}",
+		"selectRequired": "{#label} is required",
+		"title1": "There is a problem",
+		"title2": "Fix the following errors",
+		"fileUpload": {
+			"filePartiallyUploadError": "The files have not fully uploaded",
+			"fileUploadSizeError": "File must be under ",
+			"fileUploadCombinedSizeError": "Combined filesize must be under ",
+			"fileUploadTypeError": "You can't upload files of this type.",
+			"fileUploadCountSingleError": "You can only upload a single file",
+			"fileUploadCountMaxError": "You can only upload {maxFiles} files",
+			"fileUploadCountMinError": "{labelText} requires {minimumRequiredFiles} files",
+			"fileUploadSelectedFileMaxError": "The selected file must be smaller than {size}MB"
+		},
+		"ukAddressField": {
+			"invalidPostCodeError": "Enter a valid postcode"
+		},
+		"telephoneNumberField": {
+			"incorrectFormat": "Enter a telephone number in the correct format"
+		}
+	},
+	"components": {
+		"clientSideFileUpload": {
+			"javascriptEnableMessageTitle": "You need to have JavaScript enabled to see your selected files",
+			"description1": "Why is JavaScript required?",
+			"description2": "Without JavaScript, you will be able to select files to upload, but you won't be able to see them on this page.",
+			"description3": "Your files will still be uploaded when you hit \"Save and continue\". If you revisit this page, you will be able to see your previously uploaded files.",
+			"fileUploadBtn": "Choose file",
+			"filesUploadBtn": "Choose files",
+      "uploadFileTitle": "Upload file",
+      "formatMustBe": "Format must be",
+      "fileSizeLimitPart": "The selected file must be smaller than",
+			"table": {
+				"fileNameCol": "File name",
+				"fileSizeCol": "File size",
+				"fileProgressCol": "Progress",
+				"fileActionCol": "Action",
+				"fileActionComplete": "Complete",
+				"fileActionFailed": "Failed",
+				"deleteBtn": "Delete"
+			}
+		},
+		"freeTextField": {
+			"wordCountReminder": "You have {count} words remaining",
+			"wordCountRemainingError": "You have {count} words too many",
+			"wordCountError": "You can enter up to {count} words",
+			"error": "Error:"
+		},
+		"markAsComplete": {
+			"error": "You must select yes or no"
+		},
+		"declaration": {
+			"error": "You must declare to be able to submit this application"
+		},
+		"ukAddressField": {
+			"addressLine1": "Address line 1",
+			"addressLine2": "Address line 2",
+			"townOrCity": "Town or city",
+			"county": "County",
+			"postcode": "Postcode"
+		},
+		"yesOrNoField": {
+			"yes": "Yes",
+			"no": "No"
+		},
+		"changeRequestpage": {
+			"title": "We need you to make changes",
+			"itemOne": "The assessor has asked you to make a change to specific parts of this section.",
+			"itemTwo": "The pages where you need to make a change will be highlighted.",
+			"itemThree": "You do not need to make changes to any other pages."
+		}
+	},
+	"head": {
+		"banner": {
+			"title": "This is a new service.",
+			"tag": "beta"
+		}
+	},
+	"footer": {
+		"privacy": "Privacy",
+		"cookies": "Cookies",
+		"accessibilityStatement": "Accessibility Statement",
+		"contactUs": "Contact Us"
+	}
 }

--- a/runner/src/server/plugins/engine/views/components/clientsidefileuploadfield.html
+++ b/runner/src/server/plugins/engine/views/components/clientsidefileuploadfield.html
@@ -74,12 +74,18 @@
     <div id="{{ component.model.id }}"
          class="govuk-form-group {% if component.model.errorMessage %}govuk-form-group--error{% endif %}">
 
-        {% if component.model.hideTitle == false %}
-            {{ govukLabel(component.model.label) }}
-        {% endif %}
+        <label class="govuk-label govuk-label--s" for="{{ component.model.id }}" id="{{ component.model.id }}-label">
+         {{ i18nGetTranslation("components.clientSideFileUpload.uploadFileTitle") }}
+        </label>
 
         {% if component.model.hint %}
-            {{ govukHint(component.model.hint) }}
+            <div id="{{ component.model.id }}-hint" class="govuk-hint">
+                {{ component.model.hint.text }}
+            </div>
+        {% else %}
+            <div id="{{ component.model.id }}-hint" class="govuk-hint" aria-hidden="true">
+               <!-- File requirements will be populated using js only if exist else empty -->
+            </div>
         {% endif %}
 
         <p class="govuk-error-message">
@@ -191,6 +197,55 @@
     </div>
 
     <script>
+        const formatAcceptedFileTypes = () => {
+            const mimeToExt = {
+                'image/jpeg': 'jpg',
+                'image/jpg': 'jpg',
+                'image/png': 'png',
+                'application/pdf': 'pdf',
+                'text/plain': 'txt',
+                'application/msword': 'doc',
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+                'application/vnd.oasis.opendocument.text': 'odf',
+                'text/csv': 'csv',
+                'application/vnd.ms-excel': 'xls',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx'
+            };
+
+            const acceptedFiles = "{{ component.model.dropzoneConfig.acceptedFiles | safe }}";
+            if (!acceptedFiles) return "pdf, jpg, png, or xlsx";
+
+            const fileTypes = new Set();
+            acceptedFiles.split(',').forEach(type => {
+                type = type.trim();
+                if (mimeToExt[type]) {
+                    fileTypes.add(mimeToExt[type]);
+                }
+            });
+
+            const types = Array.from(fileTypes);
+            if (types.length === 0) return "pdf, jpg, png, docx, csv, odf or xlsx";
+            if (types.length === 1) return types[0];
+            if (types.length === 2) return `${types[0]} or ${types[1]}`;
+
+            const lastType = types[types.length - 1];
+            return `${types.slice(0, -1).join(', ')} or ${lastType}`;
+        };
+
+        const overrideHintText = () => {
+            const hintElement = document.getElementById("{{ component.model.id }}-hint");
+            if (!hintElement) return;
+
+            const fileTypes = formatAcceptedFileTypes();
+            const maxSize = {{ component.model.dropzoneConfig.maxFilesize | default(10) }};
+
+            const formatPart = "{{ i18nGetTranslation('components.clientSideFileUpload.formatMustBe') }}";
+            const sizePart = "{{ i18nGetTranslation('components.clientSideFileUpload.fileSizeLimitPart') }}";
+
+            hintElement.textContent = `${formatPart} ${fileTypes}, ${sizePart} ${maxSize}MB.`;
+        };
+
+        document.addEventListener('DOMContentLoaded', overrideHintText);
 
         const _FILE_SIZE_BASE = 1024;
         const previewTemplate = `


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FLS-1051

This PR will standardises the file upload component by:

1. Always displaying "Upload file" as the label, regardless of what's in the JSON configuration.
2. Generating a consistent hint format that shows allowed file types and size limits.
3. Converting technical MIME types to user-friendly file extensions (e.g., "application/pdf" → "pdf")

These changes ensure all file upload components have a consistent appearance and behaviour across the service while still respecting the configurations for allowed file types and size limits.

Note: English translations are temporarily used in the Welsh (cy.json) file until official translations are received.



### Screenshots of UI changes (if applicable)

<img width="924" alt="Screenshot 2025-05-02 at 14 42 46" src="https://github.com/user-attachments/assets/f076ada8-d1ac-4f48-9b38-1d4600d160a9" />

