### PR TITLE
Fix - resolve file upload failures in pre-prod environments

### DIFF
--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -82,6 +82,7 @@ secrets:
 environments:
   dev:
     variables:
+      JWT_AUTH_ENABLED: false
       PREVIEW_MODE: true
     count:
       spot: 2
@@ -104,6 +105,7 @@ environments:
 
   test:
     variables:
+      JWT_AUTH_ENABLED: false
       PREVIEW_MODE: true
     count:
       spot: 2
@@ -126,6 +128,7 @@ environments:
 
   uat:
     variables:
+      JWT_AUTH_ENABLED: false
       PREVIEW_MODE: true
     count:
       range: 2-4

--- a/runner/src/server/plugins/engine/api/RegisterFormPublishApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterFormPublishApi.ts
@@ -246,7 +246,7 @@ export class RegisterFormPublishApi implements RegisterApi {
 
         // TODO: Stop being naughty! Conditionally disabling auth for pre-prod envs is a temporary measure for getting
         // FAB into production
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
             getOptions.options.auth = jwtAuthStrategyName
         }
 
@@ -311,7 +311,7 @@ export class RegisterFormPublishApi implements RegisterApi {
                 handler: postHandler,
             }
         }
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
             postConfig.options.auth = jwtAuthStrategyName
         }
         server.route(postConfig);

--- a/runner/src/server/plugins/engine/api/RegisterS3FileUploadApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterS3FileUploadApi.ts
@@ -46,7 +46,7 @@ export class RegisterS3FileUploadApi implements RegisterApi {
             },
         }
 
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
             s3PresignUrlOption.options = {
                 auth: jwtAuthStrategyName
             }
@@ -79,7 +79,7 @@ export class RegisterS3FileUploadApi implements RegisterApi {
             },
         }
 
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
             s3GetDataOptions.options = {
                 auth: jwtAuthStrategyName
             }
@@ -117,7 +117,7 @@ export class RegisterS3FileUploadApi implements RegisterApi {
             },
         }
 
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
             deleteOptions.options = {
                 auth: jwtAuthStrategyName
             }

--- a/runner/src/server/plugins/engine/api/RegisterS3FileUploadApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterS3FileUploadApi.ts
@@ -46,7 +46,7 @@ export class RegisterS3FileUploadApi implements RegisterApi {
             },
         }
 
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
             s3PresignUrlOption.options = {
                 auth: jwtAuthStrategyName
             }
@@ -79,7 +79,7 @@ export class RegisterS3FileUploadApi implements RegisterApi {
             },
         }
 
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
             s3GetDataOptions.options = {
                 auth: jwtAuthStrategyName
             }
@@ -117,7 +117,7 @@ export class RegisterS3FileUploadApi implements RegisterApi {
             },
         }
 
-        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true") {
+        if (config.jwtAuthEnabled && config.jwtAuthEnabled === "true" && config.copilotEnv === "prod") {
             deleteOptions.options = {
                 auth: jwtAuthStrategyName
             }


### PR DESCRIPTION
### Description

**Background**

File upload is broken in pre-prod environments. The client-side request to `/s3/.../create-pre-signed-url` gives a 302 response, leading to a CORS error and upload failure, see screenshot:

![image](https://github.com/user-attachments/assets/0685333a-0000-471f-a7d0-be0b9d551877)

This has been an issue since this PR was merged five days ago: [FSPT-342 - Replace JWT auth with basic auth in pre-prod environments](https://github.com/communitiesuk/digital-form-builder-adapter/pull/178)

The issue is limited to Dev and Test environments as the change has not been deployed out to UAT, and the problem is limited to pre-prod anyway.

**What caused it?**

The main page routes (see `RegisterFormPublishApi.ts`) have JWT disabled in pre-prod. This means users / E2E tests do not obtain the application-level JWT cookie (`fsd_user_token`) after passing only perimeter basic auth. However, the S3 file upload routes in `RegisterS3FileUploadApi.ts` still require JWT authentication in pre-prod, as the additional condition `config.copilotEnv == "prod"` was never required to pass to add JWT authentication.

This mismatch meant S3 API calls in pre-prod were missing the required `fsd_user_token`, causing JWT authentication failure and the observed 302 redirect.

**Solution**

This PR modifies `RegisterS3FileUploadApi.ts` to disable JWT authentication in S3 file upload routes in pre-prod, aligning the authentication behaviour with the form publish routes. The S3 file upload routes will now rely solely on basic auth in pre-prod, which should allow file uploads to proceed correctly.

### Does it work?

![image](https://github.com/user-attachments/assets/6c241e3f-a89a-40c0-8091-53791e4015c2)

![image](https://github.com/user-attachments/assets/cae422ad-7c2b-4cce-b9d3-4d8be4778725)

