### PR TITLE
levellingup->communities domain changes

### DIFF
--- a/.run/RUNNER.run.xml
+++ b/.run/RUNNER.run.xml
@@ -8,7 +8,7 @@
     <arguments value="dev" />
     <node-interpreter value="project" />
     <envs>
-      <env name="ACCESSIBILITY_STATEMENT_URL" value="https://frontend.levellingup.gov.localhost:3008/accessibility_statement" />
+      <env name="ACCESSIBILITY_STATEMENT_URL" value="https://frontend.communities.gov.localhost:3008/accessibility_statement" />
       <env name="ALLOW_USER_TEMPLATES" value="true" />
       <env name="AWS_ACCESS_KEY_ID" value="FSDIOSFODNN7EXAMPLE" />
       <env name="AWS_BUCKET_NAME" value="fsd-bucket" />
@@ -17,22 +17,22 @@
       <env name="AWS_REGION" value="eu-west-2" />
       <env name="AWS_SECRET_ACCESS_KEY" value="fsdlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" />
       <env name="AWS_SIGNATURE_VERSION" value="v4" />
-      <env name="CONTACT_US_URL" value="https://frontend.levellingup.gov.localhost:3008/contact_us" />
-      <env name="COOKIE_POLICY_URL" value="https://frontend.levellingup.gov.localhost:3008/cookie_policy" />
+      <env name="CONTACT_US_URL" value="https://frontend.communities.gov.localhost:3008/contact_us" />
+      <env name="COOKIE_POLICY_URL" value="https://frontend.communities.gov.localhost:3008/cookie_policy" />
       <env name="E2E_MODE_ENABLED" value="false" />
-      <env name="ELIGIBILITY_RESULT_URL" value="https://frontend.levellingup.gov.localhost:3008/eligibility-result" />
-      <env name="FEEDBACK_LINK" value="https://frontend.levellingup.gov.localhost:3008/feedback" />
+      <env name="ELIGIBILITY_RESULT_URL" value="https://frontend.communities.gov.localhost:3008/eligibility-result" />
+      <env name="FEEDBACK_LINK" value="https://frontend.communities.gov.localhost:3008/feedback" />
       <env name="FORM_RUNNER_ADAPTER_REDIS_INSTANCE_URI" value="redis://localhost:6379" />
       <env name="JWT_AUTH_COOKIE_NAME" value="fsd_user_token" />
       <env name="JWT_AUTH_ENABLED" value="true" />
-      <env name="JWT_REDIRECT_TO_AUTHENTICATION_URL" value="https://authenticator.levellingup.gov.localhost:3004/sessions/sign-out" />
+      <env name="JWT_REDIRECT_TO_AUTHENTICATION_URL" value="https://authenticator.communities.gov.localhost:3004/sessions/sign-out" />
       <env name="LOG_LEVEL" value="debug" />
-      <env name="LOGOUT_URL" value="https://authenticator.levellingup.gov.localhost:3004/sessions/sign-out" />
-      <env name="MULTIFUND_URL" value="https://frontend.levellingup.gov.localhost:3008/account" />
+      <env name="LOGOUT_URL" value="https://authenticator.communities.gov.localhost:3004/sessions/sign-out" />
+      <env name="MULTIFUND_URL" value="https://frontend.communities.gov.localhost:3008/account" />
       <env name="PREVIEW_MODE" value="true" />
-      <env name="PRIVACY_POLICY_URL" value="https://frontend.levellingup.gov.localhost:3008/privacy" />
+      <env name="PRIVACY_POLICY_URL" value="https://frontend.communities.gov.localhost:3008/privacy" />
       <env name="RSA256_PUBLIC_KEY_BASE64" value="TUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FDdUZBL2xrczcwM2JEeDZYN0duUVIwVlVSOAp6eW8yUEJ6L2E2MVd0TjJCUitYWlV5cjlGaHc4K3E4YVRsbzZ0K2VJa3hENjE4eWpaQkx0cGhZVjUwcTAvOW1OCkk0QStPSURhQ1J0aWd0NDJ4ZUlrbmpydWZ5a280Q0xjV3BFc1dzSkZWSnJnR2xQTHZrMzJHMVJ5WFErOGY1dWsKVmlKbjBKbGlzbWo4bGtzc2pRSURBUUFC" />
-      <env name="SERVICE_START_PAGE" value="https://frontend.levellingup.gov.localhost:3008/account" />
+      <env name="SERVICE_START_PAGE" value="https://frontend.communities.gov.localhost:3008/account" />
       <env name="SINGLE_REDIS" value="true" />
         <env name="SSL_CERT" value="$PROJECT_DIR$/../../certs/cert.pem"/>
         <env name="SSL_KEY" value="$PROJECT_DIR$/../../certs/key.pem"/>

--- a/e2e-test/README.md
+++ b/e2e-test/README.md
@@ -33,7 +33,7 @@ As usual, always run commands in the root directory, not in the workspace direct
 1. Install the dependencies `yarn e2e install`
 2. Ensure the runner and designer are running. It can be running locally or pointed at a URL.
   - The defaults are set in cypress.config.js. `DESIGNER_URL: http://localhost:3000` and `RUNNER_URL: http://localhost:3009`. You may change this via environment variables by prepending the variable name with cypress_, e.g. `cypress_designer_url=https://..`
-  - yarn e2e-test cypress open --env DESIGNER_URL=https://form-designer.dev.access-funding.test.levellingup.gov.uk,RUNNER_URL=https://forms.dev.access-funding.test.levellingup.gov.uk
+  - yarn e2e-test cypress open --env DESIGNER_URL=https://form-designer.access-funding.dev.communities.gov.uk,RUNNER_URL=https://application-questions.access-funding.dev.communities.gov.uk
 3. Run, from the root directory
   - in headless mode `yarn e2e cypress run`
   - in interactive mode `yarn e2e cypress open` (this will open your browser)


### PR DESCRIPTION
https://mhclgdigital.atlassian.net/browse/FSPT-350

I've not touched the manifest here so that we are still associating the deployed app with both levellingup and communities domains. This is ostensibly for backwards compatibility and anyone who's eg bookmarked pages; however given this is for form designer and application questions, we could probably be much more aggressive with sunsetting the domains on this app specifically than with eg the pre- or post-award apps.