### PR TITLE
Welsh translations for radio buttons

### DIFF
--- a/runner/locales/cy.json
+++ b/runner/locales/cy.json
@@ -85,9 +85,9 @@
       "itemThree": "You do not need to make changes to any other pages."
     },
     "sectionCompletedField": {
-			"yes": "Yes, I’ve completed this section",
-			"no": "No, I’ll come back to it later",
-      "hint": "You can still edit this section before submitting your application."
+			"yes": "Ydw, rydw i wedi cwblhau'r adran hon",
+			"no": "Na, byddaf yn dod yn ôl ati yn nes ymlaen",
+      "hint": "Gallwch chi barhau i olygu'r adran hon cyn cyflwyno'ch cais."
 		}
   },
   "head": {


### PR DESCRIPTION
Ticket:
https://mhclgdigital.atlassian.net.mcas.ms/browse/FLS-1270

Description:
Adding Welsh translations for radio buttons on confirmation page

Screenshot:
<img width="1037" alt="Screenshot 2025-05-07 at 16 57 32" src="https://github.com/user-attachments/assets/217cbc81-c034-4236-a385-f3a321e9b069" />

English version of the radio buttons:
![Screenshot 2025-05-07 at 17 46 38](https://github.com/user-attachments/assets/d38fb507-f8dd-4270-802f-cdf20ed502e7)
