### PR TITLE
Start to retire the UAT environment

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy to AWS
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-UAT-Prod' || 'Build & Unit Test') }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', github.event.inputs.environment) || (github.ref == 'refs/heads/main' && 'Deploy to Test-Prod' || 'Build & Unit Test') }}
 
 permissions:
   packages: write
@@ -23,7 +23,6 @@ on:
         options:
           - dev
           - test
-          - uat
           - prod
       run_performance_tests:
         required: false
@@ -464,53 +463,9 @@ jobs:
       app_name: forms
       environment: test
       notify_slack: true
-  
-  uat_deploy:
-    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, post_test_deploy_tests ]
-    if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
-    concurrency:
-      group: 'fsd-adapter-uat'
-      cancel-in-progress: false
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
-    uses: ./.github/workflows/deploy.yml
-    secrets:
-      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
-    with:
-      environment: uat
-      alert_slack_on_failure: true
-      notify_slack_on_deployment: false
-
-  post_uat_deploy_tests:
-    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy ]
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
-    if: ${{ always()  && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'uat') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') )  }}
-    secrets:
-      FSD_GH_APP_ID: ${{ secrets.FSD_GH_APP_ID }}
-      FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
-      FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
-      FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
-      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_NOTIFICATION_CHANNEL_ID: ${{ secrets.SLACK_NOTIFICATION_CHANNEL_ID }}
-    uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
-    with:
-      run_performance_tests: ${{ inputs.run_performance_tests || true }}
-      run_e2e_tests_assessment: ${{ inputs.run_e2e_tests_assessment || false }}
-      run_e2e_tests_application: ${{ inputs.run_e2e_tests_application || true }}
-      run_static_security_python: false
-      run_zap_scan: true
-      app_name: forms
-      environment: uat
-      notify_slack: true
 
   prod_deploy:
-    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy, uat_deploy, post_uat_deploy_tests ]
+    needs: [ setup, docker-designer-build, docker-runner-build, dev_deploy, test_deploy ]
     if: ${{ always() && contains(fromJSON(needs.setup.outputs.jobs_to_run), 'prod') && (! contains(needs.*.result, 'failure') ) && (! contains(needs.*.result, 'cancelled') ) }}
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/copilot/fsd-form-designer-adapter/manifest.yml
+++ b/copilot/fsd-form-designer-adapter/manifest.yml
@@ -73,6 +73,3 @@ environments:
   test:
     count:
       spot: 2
-  uat:
-    count:
-      spot: 2

--- a/copilot/fsd-form-runner-adapter/manifest.yml
+++ b/copilot/fsd-form-runner-adapter/manifest.yml
@@ -126,38 +126,6 @@ environments:
         path: /health-check
         port: 3009
 
-  uat:
-    variables:
-      JWT_AUTH_ENABLED: false
-      PREVIEW_MODE: true
-    count:
-      range: 2-4
-      cooldown:
-        in: 60s
-        out: 30s
-      cpu_percentage:
-        value: 70
-      memory_percentage:
-        value: 80
-      requests: 30
-      response_time: 2s
-    sidecars:
-      nginx:
-        port: 8087
-        image:
-          location: xscys/nginx-sidecar-basic-auth
-        variables:
-          FORWARD_PORT: 3009
-          CLIENT_MAX_BODY_SIZE: 10m
-        secrets:
-          BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
-          BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
-    http:
-      target_container: nginx
-      healthcheck:
-        path: /health-check
-        port: 3009
-
   prod:
     http:
       alias: ['forms.access-funding.levellingup.gov.uk', 'application-questions.access-funding.communities.gov.uk']

--- a/runner/src/server/plugins/engine/api/RegisterApplicationStatusApi.ts
+++ b/runner/src/server/plugins/engine/api/RegisterApplicationStatusApi.ts
@@ -64,7 +64,7 @@ export class RegisterApplicationStatusApi implements RegisterApi {
                     * If prod environment, show 500 page
                     * The behaviour is not changing for non-prod environments
                     */
-                    if (["dev", "test", "uat", ""].includes(config.copilotEnv)) {
+                    if (["dev", "test", ""].includes(config.copilotEnv)) {
                         // you are previewing the form
                         request.logger.info(
                             ["applicationStatus"],


### PR DESCRIPTION
Ticket: https://mhclgdigital.atlassian.net/browse/FSPT-342

h ttps://github.com/communitiesuk/funding-service-requests-for-comments/discussions/17

As per the conclusion of the above RFC, we're moving away from having three pipelined environments to two (test/prod) and a free-for-all pre-merge env (dev).

This patch removes all concepts of the UAT env from the app, but won't tear down the app instances themselves yet. We'll do this manually later when all of our services have been updated and the UAT env is disconnected from all pipelines/etc.