### PR TITLE
Fix next page for multi input pages

### DIFF
--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -322,11 +322,10 @@ export class RepeatingFieldPageController extends PageController {
                         }
                     }
                 }
-
                 if (typeof query.returnUrl !== "undefined") {
                     return h.redirect(`${query.returnUrl}?${form_session_identifier}`);
                 }
-                return h.redirect(`${this.getNext(rest)}?${form_session_identifier}`);
+                return h.redirect(`${this.getNext(savedState)}?${form_session_identifier}`);
             }
 
             const modifyUpdate = (update) => {


### PR DESCRIPTION
The call to `getNext` was being passed the current page's post data, rather than the form session state, meaning that conditions weren't able to read the correct data to evaluate as true.

I've tested this locally but don't feel confident writing a good test in any meaningful amount of time. We'll have to test this thoroughly ourselves instead.

## Before - bad
![2025-06-11 17 30 32](https://github.com/user-attachments/assets/c7d0922c-04d6-46aa-b49e-5d3310debdea)

## After - good?
![2025-06-11 17 32 35](https://github.com/user-attachments/assets/095174ae-7bc5-4447-9edf-744bcd174b40)
