### PR TITLE
BAU: Handle checkbox repopulation for values containing commas

### DIFF
--- a/runner/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/runner/src/server/plugins/engine/components/CheckboxesField.ts
@@ -1,0 +1,21 @@
+import {
+    CheckboxesField as CoreCheckboxesField
+  } from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components";
+import { FormData, FormSubmissionErrors } from '@xgovformbuilder/runner/plugins/engine/types';
+  
+export class CheckboxesField extends CoreCheckboxesField {
+    getViewModel(formData: FormData, errors: FormSubmissionErrors) {
+        const viewModel = super.getViewModel(formData, errors);
+        // Assumes that checkbox values containing commas should be followed by a space (e.g., "Option 1, Option 2").
+        // Ensures consistent splitting, as list items are separated by commas without spaces.
+
+        let formDataItems = (formData[this.name] ?? "").split(/,(?!\s)/g);
+        viewModel.items = (viewModel.items ?? []).map((item) => ({
+          ...item,
+          checked: !!formDataItems.find((i) => `${item.value}` === i),
+        }));
+    
+        return viewModel;
+    }
+  }
+  

--- a/runner/src/server/plugins/engine/components/index.ts
+++ b/runner/src/server/plugins/engine/components/index.ts
@@ -9,7 +9,7 @@ export {
 } from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/AutocompleteField";
 export {
     CheckboxesField
-} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/CheckboxesField";
+} from "./CheckboxesField";
 export {ComponentBase as Component} from "./ComponentBase";
 export {ComponentCollection} from "./ComponentCollection";
 export {DateField} from "../../../../../../digital-form-builder/runner/src/server/plugins/engine/components/DateField";


### PR DESCRIPTION


### Change description
- Handle checkbox repopulation for values containing commas when navigating back to the form


- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")