### PR TITLE
FLS-1325 : Set Default Client-Side File Upload Limit to 10MB

### DIFF
--- a/designer/client/components/component-edit/ClientSideFileUploadFieldEdit.tsx
+++ b/designer/client/components/component-edit/ClientSideFileUploadFieldEdit.tsx
@@ -32,7 +32,7 @@ export const ClientSideFileUploadFieldEdit: any = ({context = AdapterComponentCo
             dropzoneConfig: {
                 maxFiles: 1,
                 parallelUploads: 1,
-                maxFilesize: 1,
+                maxFilesize: 10,
                 acceptedFiles: "",
             },
             showNoScriptWarning: false,


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FLS-1325**


### Change description

This PR updates the client-side file upload functionality by setting the default maximum file size to 10MB. The existing upload features and validations remain fully intact to ensure consistent user experience and functionality.

Key Changes:

- Default file size limit: Set to 10MB (10 * 1024 * 1024 bytes) on the client side.
- All existing upload behaviours, error messages, and validations are preserved.

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
- Uploaded files under and over 10MB to confirm correct behaviours.
- Verified that existing features (progress bar, error messages, etc.) continue to work as expected.

Following PDF's can be used for testing 

[2mb.pdf](https://github.com/user-attachments/files/21035823/2mb.pdf)
[8mb.pdf](https://github.com/user-attachments/files/21035824/8mb.pdf)
[20mb.pdf](https://github.com/user-attachments/files/21035825/20mb.pdf)

### Screenshots of UI changes (if applicable)

When default to 10MB and try to upload 20MB file 
![image](https://github.com/user-attachments/assets/8b18ffe4-1505-47bf-9e03-31fa95b7c286)

When default is to 10MB and uploading a 8MB file 
![image](https://github.com/user-attachments/assets/9e58d060-043d-432a-8f1d-51dc323e95d9)

Designer when adding a new client side file upload 
![image](https://github.com/user-attachments/assets/c0fbc1c6-88bd-44b1-ab98-9702b7b148bf)
