### PR TITLE
Restrict the user to add multiple rows of data when it is a MultiInputField inside a page

### DIFF
--- a/fsd_config/form_jsons/pfn_rp/pfn-rp-payment-profile-and-spend-forecast.json
+++ b/fsd_config/form_jsons/pfn_rp/pfn-rp-payment-profile-and-spend-forecast.json
@@ -248,7 +248,8 @@
                 "customText": {
                     "samePageTitle": "Capacity funding spend forecast",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -402,7 +403,8 @@
                 "customText": {
                     "samePageTitle": "Programme delivery funding (capital) spend forecast",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -555,7 +557,8 @@
                 "customText": {
                     "samePageTitle": "Programme delivery funding (revenue) spend forecast",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -706,7 +709,8 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 1)",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -837,7 +841,8 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 2)",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -968,7 +973,8 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 3)",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1099,7 +1105,8 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 4)",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1186,7 +1193,8 @@
                 "customText": {
                     "samePageTitle": "Off-menu interventions spend forecast",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1273,7 +1281,8 @@
                 "customText": {
                     "samePageTitle": "Management costs spend forecast",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1361,7 +1370,8 @@
                 "customText": {
                     "samePageTitle": "Unknown uses of funding forecast",
                     "samePageTableItemName": ""
-                }
+                },
+                "maxMultiInputFieldRows": 1
             },
             "controller": "RepeatingFieldPageController"
         }

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -5,12 +5,23 @@
     <input type="hidden" name="crumb" value="{{ crumb }}"/>
 
     {% if page.isRepeatingFieldPageController and details %}
-        {{ componentList(components) }}
-        {{ govukButton({
-            attributes: { id: "add-another"},
-            classes: "govuk-button govuk-button--secondary",
-            text: page.saveText
-        }) }}
+        {# maxMultiInputFieldRows allow the users to control how many data rows that can be added in MultiInputField component in a page #}
+        {% if not page.options.maxMultiInputFieldRows or not details.rows.length or page.options.maxMultiInputFieldRows > details.rows.length %}
+            {{ componentList(components) }}
+            {{ govukButton({
+                attributes: { id: "add-another" },
+                classes: "govuk-button govuk-button--secondary",
+                text: page.saveText
+            }) }}
+        {% else %}
+            {% set filteredComponents = [] %}
+            {% for component in components %}
+                {% if component.type != "MultiInputField" %}
+                    {% set _ = filteredComponents.push(component) %}
+                {% endif %}
+            {% endfor %}
+            {{ componentList(filteredComponents) }}
+        {% endif %}
         {% if page.options.customText.samePageTitle %}
             <table class="govuk-table">
                 <caption


### PR DESCRIPTION
### Change description
Adding new feature to restrict the user to add multiple data rows into MultiInputField component

For the rest of the development created a ticket [FLS-1423](https://mhclgdigital.atlassian.net/browse/FLS-1423)

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Use PFN to test this scenario and use [Payment profile and spend forecast](https://frontend.communities.gov.localhost:3008/continue_application/82534d07-eea5-4035-ae0e-6c7326e7e509?form_name=pfn-rp-payment-profile-and-spend-forecast&redirect_to_fund=True)In progress


### Screenshots of UI changes (if applicable)

No restrictions applied 

<img width="724" height="1122" alt="image" src="https://github.com/user-attachments/assets/949e833b-af51-41d1-a738-f158a37a8b96" />


With restriction applied and allow only single row to be added 

<img width="1004" height="1122" alt="image" src="https://github.com/user-attachments/assets/34882adb-672c-4e4c-b8fb-da7646623c1f" />

Cannot add multiple data rows 
<img width="1341" height="1122" alt="image" src="https://github.com/user-attachments/assets/32c84a94-a52d-40ff-870d-0d3f3638ef81" />

