### PR TITLE
FLS-1423 - Multi-input field row limit

### DIFF
--- a/designer/client/components/multiinput-field-edit/MultiInputFieldEdit.tsx
+++ b/designer/client/components/multiinput-field-edit/MultiInputFieldEdit.tsx
@@ -42,6 +42,7 @@ enum MultiInputFieldAction {
     EDIT_OPTIONS_HIDE_ROW_TITLE = "EDIT_OPTIONS_HIDE_ROW_TITLE",
     EDIT_OPTIONS_SHOW_TABLE_TITLE = "EDIT_OPTIONS_SHOW_TABLE_TITLE",
     EDIT_OPTIONS_SHOW_TABLE_ITEM_NAME = "EDIT_OPTIONS_SHOW_TABLE_ITEM_NAME",
+    EDIT_MAX_MULTI_INPUT_FIELD_ROWS = "EDIT_MAX_MULTI_INPUT_FIELD_ROWS",
 }
 
 export const MultiInputFieldEdit: any = ({context = AdapterComponentContext}) => {
@@ -92,6 +93,9 @@ export const MultiInputFieldEdit: any = ({context = AdapterComponentContext}) =>
     const [tableTitles, setTableTitles] = useState<string[]>(options.columnTitles ? options.columnTitles : []);
 
     const [showEditor, setShowEditor] = useState(false);
+
+    const [maxRows, setMaxRows] = useState<string>(selectedComponent.options?.maxMultiInputFieldRows?.toString() || "");
+
     const subComponentRef = useRef(null);
 
     const toggleShowEditor = () => {
@@ -622,6 +626,14 @@ export const MultiInputFieldEdit: any = ({context = AdapterComponentContext}) =>
                 }
             })
         }
+        if (e.type === MultiInputFieldAction.EDIT_MAX_MULTI_INPUT_FIELD_ROWS) {
+            setMaxRows(e.payload);
+            const numValue = parseInt(e.payload);
+            if (!selectedComponent.options) {
+                selectedComponent.options = {};
+            }
+            selectedComponent.options.maxMultiInputFieldRows = isNaN(numValue) || numValue <= 0 ? undefined : numValue;
+        }
     }
 
     const renderSelectedSubComponentConfigEdit = () => {
@@ -932,6 +944,26 @@ export const MultiInputFieldEdit: any = ({context = AdapterComponentContext}) =>
                            children: ["Table Item Name"]
                        }}/>
             </div>
+
+            <div className="govuk-form-group" data-test-id="max-multi-input-field-rows-wrapper">
+                <Input id="max-multi-input-field-rows" name="maxMultiInputFieldRows"
+                        onChange={(e) =>
+                            handleData({
+                                type: MultiInputFieldAction.EDIT_MAX_MULTI_INPUT_FIELD_ROWS,
+                                payload: e.target.value,
+                            })
+                        }
+                        value={maxRows}
+                        type="number"
+                        label={{
+                            className: "govuk-label--s",
+                            children: ["Maximum number of rows"]
+                        }}
+                        hint={{
+                            children: ["Set the maximum number of rows users can add. Leave empty for unlimited rows."]
+                        }}/>
+            </div>
+
             <div className="govuk-label govuk-label--s">----- Sub Components list -----</div>
             <div className="govuk-form-group">
                 <label className="govuk-label govuk-label--s" htmlFor="select-field-types">

--- a/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
+++ b/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
@@ -155,6 +155,7 @@ Feature: Multi Input Field Edit
     When I enter "First item" for "Item name"
     And I click "Save and add another"
     When I enter "Second item" for "Item name"
-    And I click "Save and add another"
+    And I click "Save"
     Then I should not see the "Save and add another" button
+    And I should not see the "Save" button
     And I should see the "Save and continue" button

--- a/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
+++ b/e2e-test/cypress/e2e/designer/multiInputFieldEdit.feature
@@ -140,3 +140,21 @@ Feature: Multi Input Field Edit
       | YesNoField         | This is a yes no field    |                                                 |
       | MonthYearField     | This is a month field     | {"items": [{"name": "Month"},{"name": "Year"}]} |
       | MultilineTextField | This is a multiline field |                                                 |
+
+  Scenario: Test multi input field with maximum rows configuration
+    And I continue create a component
+      | page       | component         | title                   |
+      | First page | Multi Input Field | Which eggs do you like? |
+    And I add table title name "MaxRowsTest"
+    And I configure maximum rows as "2"
+    And I add child components
+      | component | title      | options | additional | listItem | name     |
+      | TextField | Item name  | {}      | false      |          | itemname |
+    And I save component
+    And I preview the page "First page" without href
+    When I enter "First item" for "Item name"
+    And I click "Save and add another"
+    When I enter "Second item" for "Item name"
+    And I click "Save and add another"
+    Then I should not see the "Save and add another" button
+    And I should see the "Save and continue" button

--- a/e2e-test/cypress/support/step_definitions/runner/i_configure_multiinput_field_max_rows.js
+++ b/e2e-test/cypress/support/step_definitions/runner/i_configure_multiinput_field_max_rows.js
@@ -1,0 +1,17 @@
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+When("I configure maximum rows as {string}", (maxRows) => {
+  cy.get("#max-multi-input-field-rows").type(maxRows);
+});
+
+When("I click {string}", (buttonText) => {
+  cy.findByRole("button", { name: buttonText }).click();
+});
+
+Then("I should not see the {string} button", (buttonText) => {
+  cy.findByRole("button", { name: buttonText }).should('not.exist');
+});
+
+Then("I should see the {string} button", (buttonText) => {
+  cy.findByRole("button", { name: buttonText }).should('exist');
+});

--- a/fsd_config/form_jsons/pfn_rp/pfn-rp-payment-profile-and-spend-forecast.json
+++ b/fsd_config/form_jsons/pfn_rp/pfn-rp-payment-profile-and-spend-forecast.json
@@ -102,7 +102,8 @@
                             "Capacity funding (2033-34)",
                             "Capacity funding (2034-35)",
                             "Capacity funding (2035-36)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for capacity funding throughout the programme.",
@@ -248,8 +249,7 @@
                 "customText": {
                     "samePageTitle": "Capacity funding spend forecast",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -278,7 +278,8 @@
                             "Programme delivery funding - capital (2033-34)",
                             "Programme delivery funding - capital (2034-35)",
                             "Programme delivery funding - capital (2035-36)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for programme delivery funding (capital) throughout the programme.",
@@ -403,8 +404,7 @@
                 "customText": {
                     "samePageTitle": "Programme delivery funding (capital) spend forecast",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -433,7 +433,8 @@
                             "Programme delivery funding - revenue (2033-34)",
                             "Programme delivery funding - revenue (2034-35)",
                             "Programme delivery funding - revenue (2035-36)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for programme delivery funding (revenue) throughout the programme.",
@@ -557,8 +558,7 @@
                 "customText": {
                     "samePageTitle": "Programme delivery funding (revenue) spend forecast",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -605,7 +605,8 @@
                             "Safety and security (2026-27)",
                             "Transport (2026-27)",
                             "Work, productivity and skills (2026-27)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for pre-approved interventions in year 1.",
@@ -709,8 +710,7 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 1)",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -737,7 +737,8 @@
                             "Safety and security (2027-28)",
                             "Transport (2027-28)",
                             "Work, productivity and skills (2027-28)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for pre-approved interventions in year 2.",
@@ -841,8 +842,7 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 2)",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -869,7 +869,8 @@
                             "Safety and security (2028-29)",
                             "Transport (2028-29)",
                             "Work, productivity and skills (2028-29)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for pre-approved interventions in year 3.",
@@ -973,8 +974,7 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 3)",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1001,7 +1001,8 @@
                             "Safety and security (2029-30)",
                             "Transport (2029-30)",
                             "Work, productivity and skills (2029-30)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for pre-approved interventions in year 4.",
@@ -1105,8 +1106,7 @@
                 "customText": {
                     "samePageTitle": "Pre-approved interventions spend forecast (Year 4)",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1129,7 +1129,8 @@
                             "Off-menu interventions (2027-28)",
                             "Off-menu interventions (2028-29)",
                             "Off-menu interventions (2029-30)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for any off-menu interventions in the first investment period.",
@@ -1193,8 +1194,7 @@
                 "customText": {
                     "samePageTitle": "Off-menu interventions spend forecast",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1217,7 +1217,8 @@
                             "Management costs (2027-28)",
                             "Management costs (2028-29)",
                             "Management costs (2029-30)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us your indicative spend forecast for management costs in the first investment period.",
@@ -1281,8 +1282,7 @@
                 "customText": {
                     "samePageTitle": "Management costs spend forecast",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         },
@@ -1305,7 +1305,8 @@
                             "Unknown uses of funding (2027-28)",
                             "Unknown uses of funding (2028-29)",
                             "Unknown uses of funding (2029-30)"
-                        ]
+                        ],
+                        "maxMultiInputFieldRows": 1
                     },
                     "type": "MultiInputField",
                     "title": "Tell us about any unknown uses of funding in the first investment period.",
@@ -1370,8 +1371,7 @@
                 "customText": {
                     "samePageTitle": "Unknown uses of funding forecast",
                     "samePageTableItemName": ""
-                },
-                "maxMultiInputFieldRows": 1
+                }
             },
             "controller": "RepeatingFieldPageController"
         }

--- a/runner/locales/cy.json
+++ b/runner/locales/cy.json
@@ -2,6 +2,8 @@
   "signOut": "Allgofnodi",
   "markAsComplete": "A ydych chi eisiau marcio bod yr adran hon wedi'i chwblhau?",
   "removeText": "Dileu",
+  "saveText": "Cadw",
+  "saveAndAddAnotherText": "Cadw ac ychwanegu un arall",
   "validation": {
     "required": "{#label} yn ofynnol",
     "max": "{#label} rhaid iddo fod yn {#limit} nod neu lai",

--- a/runner/locales/en.json
+++ b/runner/locales/en.json
@@ -2,6 +2,8 @@
 	"signOut": "Sign out",
 	"markAsComplete": "Have you completed this section?",
 	"removeText": "Remove",
+	"saveText": "Save",
+	"saveAndAddAnotherText": "Save and add another",
 	"validation": {
 		"required": "{#label} is required",
 		"max": "{#label} must be {#limit} characters or less",

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -97,13 +97,11 @@ export class RepeatingFieldPageController extends PageController {
         this.tableEmptyMessageTitle = this.options.customText && this.options.customText.samePageTableItemName ? `You have not added any ${this.options.customText.samePageTableItemName}s yet` : "You have not added any costs yet";
         //@ts-ignore
         this.tableEmptyMessageHint = this.options.customText && this.options.customText.samePageTableItemName ? `Each ${this.options.customText.samePageTableItemName} you add will be shown here` : "Each cost you add will be shown here";
-        this.saveText = "Save and add another";
         if (model?.def?.metadata?.isWelsh) {
             //@ts-ignore
             this.tableEmptyMessageTitle = this.options.customText && this.options.customText.samePageTableItemName ? `Nid ydych chi wedi ychwanegu unrhyw ${this.options.customText.samePageTableItemName} eto` : "Nid ydych chi wedi ychwanegu unrhyw gostau eto";
             //@ts-ignore
             this.tableEmptyMessageHint = this.options.customText && this.options.customText.samePageTableItemName ? `Bydd pob ${this.options.customText.samePageTableItemName} yr ychwanegwch yn cael ei dangos yma` : "Bydd pob cost yr ychwanegwch yn cael ei dangos yma";
-            this.saveText = "Cadw ac ychwanegu un arall";
         }
     }
 
@@ -246,7 +244,9 @@ export class RepeatingFieldPageController extends PageController {
             const currentRowCount = rows ? rows.length : 0;
 
             if (maxRows && (currentRowCount >= maxRows - 1)) {
-                this.saveText = this.model?.def?.metadata?.isWelsh ? "Cadw" : "Save";
+                this.saveText = request.i18n.__("saveText");
+            } else {
+                this.saveText = request.i18n.__("saveAndAddAnotherText");
             }
         }
     }

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -219,6 +219,8 @@ export class RepeatingFieldPageController extends PageController {
                 headings: this.inputComponent.options.columnTitles,
                 rows,
             };
+            
+            response.source.context.maxMultiInputFieldRows = this.inputComponent.options?.maxMultiInputFieldRows;
         }
     }
 

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -241,6 +241,13 @@ export class RepeatingFieldPageController extends PageController {
             };
             
             response.source.context.maxMultiInputFieldRows = this.inputComponent.options?.maxMultiInputFieldRows;
+
+            const maxRows = this.inputComponent.options?.maxMultiInputFieldRows;
+            const currentRowCount = rows ? rows.length : 0;
+
+            if (maxRows && (currentRowCount >= maxRows - 1)) {
+                this.saveText = this.model?.def?.metadata?.isWelsh ? "Cadw" : "Save";
+            }
         }
     }
 

--- a/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/RepeatingFieldPageController.ts
@@ -126,6 +126,26 @@ export class RepeatingFieldPageController extends PageController {
         return parentSchema;
     }
 
+    async validateComponentFunctions(request, viewModel) {
+        let errors = await super.validateComponentFunctions(request, viewModel);
+        const maxRows = this.inputComponent.options?.maxMultiInputFieldRows;
+        if (maxRows) {
+            const {adapterCacheService} = request.services([]);
+            const state = await adapterCacheService.getState(request);
+            const currentRows = this.getPartialState(state) || [];
+            if (currentRows.length >= maxRows) {
+                const rowText = maxRows === 1 ? "row" : "rows";
+                errors.push({
+                    path: this.inputComponent.name,
+                    name: this.inputComponent.name,
+                    text: `You cannot add more than ${maxRows} ${rowText}`,
+                });
+            }
+        }
+        
+        return errors;
+    }
+
     makeGetRouteHandler() {
         return async (request: HapiRequest, h: HapiResponseToolkit) => {
             const {query} = request;

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -6,7 +6,12 @@
 
     {% if page.isRepeatingFieldPageController and details %}
         {# maxMultiInputFieldRows allow the users to control how many data rows that can be added in MultiInputField component in a page #}
-        {% if not page.options.maxMultiInputFieldRows or not details.rows.length or page.options.maxMultiInputFieldRows > details.rows.length %}
+        {% set multiInputLimitReached = false %}
+        {% if maxMultiInputFieldRows and details.rows.length >= maxMultiInputFieldRows %}
+            {% set multiInputLimitReached = true %}
+        {% endif %}
+
+        {% if not multiInputLimitReached %}
             {{ componentList(components) }}
             {{ govukButton({
                 attributes: { id: "add-another" },


### PR DESCRIPTION
### Ticket

[Add Tests and Designer Support for MultiInput Row Restriction in Digital Form Builder Adapter](https://mhclgdigital.atlassian.net/browse/FLS-1423)

### Changes made

- Moving the new multi-input field option maxMultiInputFieldRows to the component not the page
- Allowing multi-input row limit to be set in Designer
- Backend validation in Runner for multi-input field row limit
- Use 'Save' not 'Save and add another' on button if not possible to add another
- Using translation module for cleaner switch to Welsh on save button text

### How to test

- Run Designer + Runner locally
- Go to Designer (@ https://form-designer.communities.gov.localhost:3000/app if you are running containers from Docker Runner repo)
- Click "Create a new form"
- Click "Import saved form" and select `fsd_config/form_jsons/pfn_rp/pfn-rp-payment-profile-and-spend-forecast.json`
- Click on the square component on the page titled "Tell us your indicative spend forecast for capacity funding throughout the programme."
- Note the new field "Maximum number of rows" with value 1
- Change this to a new test value X and click "Save" at the bottom
- Click "Preview" on this page
- Enter X - 1 inputs and note that the grey button says "Save" not "Save and add another"
- Enter X inputs and note that the multi-input field sub-components and grey "Save" button disappear when the row limit is reached

### Screenshots

<img width="1916" height="966" alt="image" src="https://github.com/user-attachments/assets/14c481e3-6f3b-4cd5-83ab-0b85176ee700" />
