### PR TITLE
FLS-1409: Add Error Summary to 'Check Your Answers' Page for Accessibility Compliance

### DIFF
--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -1,5 +1,7 @@
 {% from "partials/summary-detail.html" import summaryDetail %}
 {% from "components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "components/radios/macro.njk" import govukRadios %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "button/macro.njk" import govukButton %}
 {% extends 'layout.html' %}
 
@@ -30,6 +32,14 @@
                 {% if not hasMultipleSections and not details[0].hideTitle %}
                 <span class="govuk-caption-l">{{ details[0].title }}</span>
                 {% endif %}
+
+                {% if markAsCompleteComponent and markAsCompleteError %}
+                    {{ govukErrorSummary({
+                        titleText: "There is a problem",
+                        errorList: [{ text: markAsCompleteError, href: "#markAsComplete-error" }]
+                    }) }}
+                {% endif %}
+
                 <h1 class="govuk-heading-l">
                     {% if callback and callback.title %}
                         {{ callback.title }}
@@ -98,40 +108,39 @@
                         {% endif %}
 
                         {% if markAsCompleteComponent %}
-                            <div class="govuk-!-margin-top-9 govuk-form-group {{ 'govuk-form-group--error' if markAsCompleteError }}">
-                                {% if markAsCompleteError %}
-                                    <span id="nationality-error" class="govuk-error-message">
-                                    <span class="govuk-visually-hidden">Error:</span> {{ markAsCompleteError }}</span>
-                                {% endif %}
-                                <fieldset class="govuk-fieldset">
-                                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                        <h1 class="govuk-fieldset__heading">
-                                            {{ i18nGetTranslation("markAsComplete") }}
-                                        </h1>
-                                    </legend>
-                                    <div class="govuk-radios" data-module="govuk-radios">
-                                        <div class="govuk-radios__item">
-                                            <input class="govuk-radios__input" id="markAsComplete-yes"
-                                                   name="markAsComplete" type="radio" value="true"
-                                                   {% if markAsComplete %}checked{% endif %}>
-                                            <label class="govuk-label govuk-radios__label" for="markAsComplete-yes">
-                                                {{ i18nGetTranslation("components.sectionCompletedField.yes") }}
-                                            </label>
-                                            <div class="govuk-hint govuk-radios__hint">
-                                                {{ i18nGetTranslation("components.sectionCompletedField.hint") }}
-                                            </div>
-                                        </div>
-                                        <div class="govuk-radios__item">
-                                            <input class="govuk-radios__input" id="markAsComplete-no"
-                                                   name="markAsComplete" type="radio" value="false"
-                                                   {% if markAsComplete == false %}checked{% endif %}>
-                                            <label class="govuk-label govuk-radios__label" for="markAsComplete-no">
-                                                {{ i18nGetTranslation("components.sectionCompletedField.no") }}
-                                            </label>
-                                        </div>
-                                    </div>
-                                </fieldset>
-                            </div>
+                            {% if markAsCompleteError %}
+                                {% set errorMessageObj = { text: markAsCompleteError } %}
+                            {% else %}
+                                {% set errorMessageObj = null %}
+                            {% endif %}
+                            {{ govukRadios({
+                                name: "markAsComplete",
+                                fieldset: {
+                                    legend: {
+                                        text: i18nGetTranslation("markAsComplete"),
+                                        isPageHeading: false,
+                                        classes: "govuk-fieldset__legend--m"
+                                    }
+                                },
+                                items: [
+                                    {
+                                        value: true,
+                                        text: i18nGetTranslation("components.sectionCompletedField.yes"),
+                                        id: "markAsComplete-yes",
+                                        checked: (markAsComplete === true),
+                                        hint: {
+                                            text: i18nGetTranslation("components.sectionCompletedField.hint")
+                                        }
+                                    },
+                                    {
+                                        value: false,
+                                        checked: (markAsComplete === false),
+                                        id: "markAsComplete-no",
+                                        text: i18nGetTranslation("components.sectionCompletedField.no")
+                                    }
+                                ],
+                                errorMessage: errorMessageObj
+                            }) }}
                         {% endif %}
 
                         {% if fees and fees.details|length %}


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FLS-1409**

### Change description

This PR addresses Issue ID: DAC_Missing_Error_Summary_01, which highlights the absence of an error summary on the ‘Check your answers’ page when a user attempts to proceed with incomplete or incorrect information.

Page Affected: Summary page (last page)

- [x] Unit tests and other appropriate tests added or updated
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Go to any of the summary page also grant should have the mark-as-complete enabled 


### Screenshots of UI changes (if applicable)

<img width="1488" height="1322" alt="image" src="https://github.com/user-attachments/assets/f7e4bb7f-1c30-48cd-b24c-4f83b3eb32d3" />
