### PR TITLE
Remove unwanted start page from the form config

### DIFF
--- a/fsd_config/form_jsons/cof25/eoi/en/declaration-25.json
+++ b/fsd_config/form_jsons/cof25/eoi/en/declaration-25.json
@@ -33,8 +33,7 @@
                     "path": "/summary"
                 }
             ],
-            "section": "FabDefault",
-            "controller": "start.js"
+            "section": "FabDefault"
         }
     ],
     "lists": [

--- a/fsd_config/form_jsons/dpif_r3/dpif-name-your-application.json
+++ b/fsd_config/form_jsons/dpif_r3/dpif-name-your-application.json
@@ -30,8 +30,7 @@
                     "path": "/summary"
                 }
             ],
-            "section": "ScxYon",
-            "controller": "start.js"
+            "section": "ScxYon"
         }
     ],
     "lists": [],

--- a/fsd_config/form_jsons/dpif_r4/name-your-application.json
+++ b/fsd_config/form_jsons/dpif_r4/name-your-application.json
@@ -30,8 +30,7 @@
                     "path": "/summary"
                 }
             ],
-            "section": "ScxYon",
-            "controller": "start.js"
+            "section": "ScxYon"
         }
     ],
     "lists": [],

--- a/fsd_config/form_jsons/sf_r1/organisation-name-sample-cy.json
+++ b/fsd_config/form_jsons/sf_r1/organisation-name-sample-cy.json
@@ -44,8 +44,7 @@
           "condition": "lgQzEs"
         }
       ],
-      "section": "FabDefault",
-      "controller": "start.js"
+      "section": "FabDefault"
     },
     {
       "path": "/alternative-organisation-names",

--- a/fsd_config/form_jsons/sf_r1/organisation-name-sample.json
+++ b/fsd_config/form_jsons/sf_r1/organisation-name-sample.json
@@ -44,8 +44,7 @@
           "condition": "lgQzEs"
         }
       ],
-      "section": "FabDefault",
-      "controller": "start.js"
+      "section": "FabDefault"
     },
     {
       "path": "/alternative-organisation-names",

--- a/fsd_config/form_jsons/sf_r1/project-name-sample-cy.json
+++ b/fsd_config/form_jsons/sf_r1/project-name-sample-cy.json
@@ -47,8 +47,7 @@
           "path": "/project-overview"
         }
       ],
-      "section": "FabDefault",
-      "controller": "start.js"
+      "section": "FabDefault"
     }
   ],
   "lists": [],

--- a/fsd_config/form_jsons/sf_r1/project-name-sample.json
+++ b/fsd_config/form_jsons/sf_r1/project-name-sample.json
@@ -47,8 +47,7 @@
           "path": "/project-overview"
         }
       ],
-      "section": "FabDefault",
-      "controller": "start.js"
+      "section": "FabDefault"
     }
   ],
   "lists": [],


### PR DESCRIPTION
**Ticket: https://mhclgdigital.atlassian.net/browse/FLS-1408**


### Change description

If there is a form json which is not having explicit start page and if we upload that into FAB and then download it FAB side think that first page is already the first page and it adds the "start.js" controller and in the first page we should not have any input fields designer and runner works fine it correctly adding the controllers but not from the FAB so here I am removing the unnecessary additions of that controller to fix some of the forms 

- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Use any of the updated funds and forms to test when you have not given any data for the first page it should show an error if that input is a mandatory one.
