### PR TITLE
Make LPA code question optional in DPIF R4

### DIFF
--- a/fsd_config/form_jsons/dpif_r4/organisation-information.json
+++ b/fsd_config/form_jsons/dpif_r4/organisation-information.json
@@ -200,7 +200,9 @@
             "title": "Local Planning Authority code",
             "components": [
                 {
-                    "options": {},
+                    "options": {
+                        "required": false
+                    },
                     "type": "TextField",
                     "title": "Local Planning Authority code",
                     "hint": "",


### PR DESCRIPTION
Some DPIF applicants have been unable to submit their applications because they didn't have access to the mandatory LPA (Local Planning Authority) codes required in the application form. The LPA code field was mistakenly added to Round 4 of the application process when implementing organisation data standards, even though these codes are typically used internally and not information that LPAs would readily know.

It was determined that LPA codes can be derived from existing datasets and don't need to be collected directly from applicants. Thus we can make the field optional to allow applications to proceed, then backfill the data later from authoritative sources.