### PR TITLE
FLS-1413: Update backlink text and logic

### DIFF
--- a/e2e-test/cypress/e2e/runner/getConditionEvaluationContext.feature
+++ b/e2e-test/cypress/e2e/runner/getConditionEvaluationContext.feature
@@ -13,7 +13,7 @@ Feature: Get Condition Evaluation Context
     * I enter "d'egg" for "Surname"
     * I continue
     Then I see "There Is Someone Called Applicant"
-    When I go back to application overview
+    When I go back to previous page
     And I enter "{selectAll}{backspace}Scrambled" for "First name"
     * I continue
     * I see "TestConditions"

--- a/e2e-test/cypress/support/step_definitions/common/i_go_back.js
+++ b/e2e-test/cypress/support/step_definitions/common/i_go_back.js
@@ -1,5 +1,5 @@
 import { When } from "@badeball/cypress-cucumber-preprocessor";
 
-When("I go back to application overview", () => {
-  cy.findByRole("link", { name: "Go back to application overview" }).click();
+When("I go back to previous page", () => {
+  cy.findByRole("link", { name: "Go back to previous page" }).click();
 });

--- a/e2e-test/cypress/support/step_definitions/runner/back_link_fallback.js
+++ b/e2e-test/cypress/support/step_definitions/runner/back_link_fallback.js
@@ -1,7 +1,7 @@
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
 Then("The back link href is selected is {string}", (href) => {
-  cy.findByRole("link", { name: "Go back to application overview" })
+  cy.findByRole("link", { name: "Go back to previous page" })
     .should("have.attr", "href")
     .and("eq", href);
 });

--- a/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
@@ -690,7 +690,7 @@ export class PageControllerBase {
             backLinkFallback: this.backLinkFallback,
             returnUrl: state.callback?.returnUrl,
             isWelsh: this.model.def?.metadata?.isWelsh,
-            isEligibilityForm: state["metadata"]?.has_eligibility ?? false,
+            isEligibilityForm: state["metadata"]?.has_eligibility ?? false
             });
             //@ts-ignore
             this.backLink = viewModel.backLink = backLink;
@@ -1060,7 +1060,8 @@ export class PageControllerBase {
             startPage: this.model.def.startPage,
             backLinkFallback: this.backLinkFallback,
             returnUrl: state.callback?.returnUrl,
-            isWelsh: this.model.def?.metadata?.isWelsh
+            isWelsh: this.model.def?.metadata?.isWelsh,
+            isEligibilityForm: state["metadata"]?.has_eligibility ?? false
         });
         //@ts-ignore
         this.backLink = viewModel.backLink = backLink;

--- a/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/page-controllers/PageControllerBase.ts
@@ -1052,21 +1052,25 @@ export class PageControllerBase {
     private renderWithErrors(request, h, payload, num, progress, errors, state) {
         const viewModel = this.getViewModel(payload, num, errors);
 
-        // Compute back link
-        const { backLink, backLinkText } = getBackLink({
-            progress,
-            thisPath: this.path,
-            currentPath: `/${this.model.basePath}${this.path}${request.url.search}`,
-            startPage: this.model.def.startPage,
-            backLinkFallback: this.backLinkFallback,
-            returnUrl: state.callback?.returnUrl,
-            isWelsh: this.model.def?.metadata?.isWelsh,
-            isEligibilityForm: state["metadata"]?.has_eligibility ?? false
-        });
-        //@ts-ignore
-        this.backLink = viewModel.backLink = backLink;
-        //@ts-ignore
-        this.backLinkText = viewModel.backLinkText = backLinkText;
+        const previewMode = state?.previewMode || false;
+
+        if (!previewMode) {
+            // Compute back link
+            const { backLink, backLinkText } = getBackLink({
+                progress,
+                thisPath: this.path,
+                currentPath: `/${this.model.basePath}${this.path}${request.url.search}`,
+                startPage: this.model.def.startPage,
+                backLinkFallback: this.backLinkFallback,
+                returnUrl: state.callback?.returnUrl,
+                isWelsh: this.model.def?.metadata?.isWelsh,
+                isEligibilityForm: state["metadata"]?.has_eligibility ?? false
+            });
+            //@ts-ignore
+            this.backLink = viewModel.backLink = backLink;
+            //@ts-ignore
+            this.backLinkText = viewModel.backLinkText = backLinkText;
+        }
 
         this.setPhaseTag(viewModel);
         this.setFeedbackDetails(viewModel, request);

--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -43,7 +43,7 @@ export class SummaryPageController extends PageController {
             if (this.model.def.skipSummary) {
                 return this.makePostRouteHandler()(request, h);
             }
-            if (!progress) {
+            if (!progress || progress.length === 0) {
                 const currentPath = `/${this.model.basePath}${this.path}${request.url.search}`;
                 //@ts-ignore
                 progress.push(currentPath);

--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -52,11 +52,6 @@ export class SummaryPageController extends PageController {
                 //@ts-ignore
                 state = await adapterCacheService.getState(request);
             }
-            if (state["metadata"] && state["metadata"]["has_eligibility"]) {
-                this.isEligibility = state["metadata"]["has_eligibility"];
-                this.backLinkText = UtilHelper.getBackLinkText(BackLinkType.Eligibility, this.model.def?.metadata?.isWelsh);
-                this.backLink = state.callback?.returnUrl;
-            }
 
             if (state["metadata"] && state["metadata"]["is_read_only_summary"]) {
                 this.formattingDataInTheStateToOriginal(state, model);

--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -85,6 +85,8 @@ export class SummaryPageController extends PageController {
             await adapterCacheService.mergeState(request, { progress });
             state = await adapterCacheService.getState(request);
 
+            const isEligibilityForm = this.isEligibility = state["metadata"]?.has_eligibility ?? false
+
             // Compute back link
             const { backLink, backLinkText } = getBackLink({
             progress,
@@ -93,7 +95,8 @@ export class SummaryPageController extends PageController {
             startPage,
             backLinkFallback: this.backLinkFallback,
             returnUrl: state.callback?.returnUrl,
-            isWelsh: this.model.def?.metadata?.isWelsh
+            isWelsh: this.model.def?.metadata?.isWelsh,
+            isEligibilityForm: isEligibilityForm
             });
             //@ts-ignore
             viewModel.backLink = backLink;

--- a/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/page-controllers/SummaryPageController.ts
@@ -7,7 +7,7 @@ import {PageController} from "./PageController";
 import {isMultipleApiKey} from "@xgovformbuilder/model";
 import {config} from "../../utils/AdapterConfigurationSchema";
 import {redirectTo} from "../util/helper";
-import {UtilHelper} from "../../utils/UtilHelper";
+import {UtilHelper, BackLinkType} from "../../utils/UtilHelper";
 import {UkAddressField} from "../components";
 
 const LOGGER_DATA = {
@@ -51,7 +51,7 @@ export class SummaryPageController extends PageController {
             }
             if (state["metadata"] && state["metadata"]["has_eligibility"]) {
                 this.isEligibility = state["metadata"]["has_eligibility"];
-                this.backLinkText = UtilHelper.getBackLinkText(true, this.model.def?.metadata?.isWelsh);
+                this.backLinkText = UtilHelper.getBackLinkText(BackLinkType.Eligibility, this.model.def?.metadata?.isWelsh);
                 this.backLink = state.callback?.returnUrl;
             }
 
@@ -63,9 +63,9 @@ export class SummaryPageController extends PageController {
             }
             //@ts-ignore
             const viewModel = new AdapterSummaryViewModel(this.title, model, state, request, this);
-            
+
             await this.handlePreviewMode(request, viewModel);
-            
+
             if (viewModel.endPage) {
                 return redirectTo(request, h, `/${model.basePath}${viewModel.endPage.path}`);
             }
@@ -74,7 +74,7 @@ export class SummaryPageController extends PageController {
                 //@ts-ignore
                 viewModel.isReadOnlySummary = true;
                 //@ts-ignore
-                viewModel.backLinkText = UtilHelper.getBackLinkText(true, this.model.def?.metadata?.isWelsh);
+                viewModel.backLinkText = UtilHelper.getBackLinkText(BackLinkType.Eligibility, this.model.def?.metadata?.isWelsh);
                 //@ts-ignore
                 viewModel.backLink = state.callback?.returnUrl;
             }

--- a/runner/src/server/plugins/engine/util/navigationUtils.ts
+++ b/runner/src/server/plugins/engine/util/navigationUtils.ts
@@ -1,0 +1,50 @@
+import {UtilHelper, BackLinkType} from "../../utils/UtilHelper";
+
+interface BackLinkParams {
+  progress: string[];
+  thisPath: string;
+  currentPath: string;
+  startPage: string;
+  backLinkFallback?: string;
+  returnUrl?: string;
+  isWelsh: boolean;
+}
+
+export function updateProgress(progress: any, currentPath: string): void {
+  const lastVisited = progress[progress.length - 1];
+  if (!lastVisited || lastVisited !== currentPath) {
+    if (progress[progress.length - 2] === currentPath) {
+      progress.pop();
+    } else {
+      progress.push(currentPath);
+    }
+  }
+}
+
+export function getBackLink({
+  progress,
+  thisPath,
+  currentPath,
+  startPage,
+  backLinkFallback = '/',
+  returnUrl,
+  isWelsh
+}: BackLinkParams) {
+  const isFirstPage = thisPath === startPage;
+
+  if (isFirstPage && returnUrl) {
+    return {
+      backLink: returnUrl,
+      backLinkText: UtilHelper.getBackLinkText(BackLinkType.ApplicationOverview, isWelsh)
+    };
+  }
+
+  const currentIndex = progress.lastIndexOf(currentPath);
+  const previousPage = currentIndex > 0 ? progress[currentIndex - 1] : undefined;
+  const safeBackLink = previousPage ?? backLinkFallback;
+
+  return {
+    backLink: safeBackLink,
+    backLinkText: UtilHelper.getBackLinkText(BackLinkType.PreviousPage, isWelsh)
+  };
+}

--- a/runner/src/server/plugins/engine/util/navigationUtils.ts
+++ b/runner/src/server/plugins/engine/util/navigationUtils.ts
@@ -8,6 +8,7 @@ interface BackLinkParams {
   backLinkFallback?: string;
   returnUrl?: string;
   isWelsh: boolean;
+  isEligibilityForm: boolean;
 }
 
 export function updateProgress(progress: any, currentPath: string): void {
@@ -28,9 +29,17 @@ export function getBackLink({
   startPage,
   backLinkFallback = '/',
   returnUrl,
-  isWelsh
+  isWelsh,
+  isEligibilityForm
 }: BackLinkParams) {
   const isFirstPage = thisPath === startPage;
+
+  if (isEligibilityForm && isFirstPage && returnUrl) {
+    return {
+      backLink: returnUrl,
+      backLinkText: UtilHelper.getBackLinkText(BackLinkType.Eligibility, isWelsh)
+    };
+  }
 
   if (isFirstPage && returnUrl) {
     return {

--- a/runner/src/server/plugins/utils/UtilHelper.ts
+++ b/runner/src/server/plugins/utils/UtilHelper.ts
@@ -1,17 +1,21 @@
+export enum BackLinkType {
+  Eligibility,
+  PreviousPage,
+  ApplicationOverview
+}
+
 export class UtilHelper {
   // Helper class to add translations in runner
-  public static getBackLinkText(eligibility: boolean, isWelsh: boolean) {
-    if (eligibility) {
-      if (isWelsh) {
-        return "Yn ôl at eich ceisiadau";
-      }
-      return "Back to your applications";
-    } else {
-      if (isWelsh) {
-        return "Yn ôl i'r trosolwg o'r cais";
-      } else {
-        return "Go back to application overview";
-      }
+  public static getBackLinkText(type: BackLinkType, isWelsh: boolean): string {
+    switch (type) {
+      case BackLinkType.Eligibility:
+        return isWelsh ? "Yn ôl at eich ceisiadau" : "Back to your applications";
+      case BackLinkType.PreviousPage:
+        return isWelsh ? "" : "Go back to previous page";
+      case BackLinkType.ApplicationOverview:
+        return isWelsh ? "Yn ôl i'r trosolwg o'r cais" : "Go back to application overview";
+      default:
+        return "";
     }
   }
 }

--- a/runner/src/server/plugins/utils/UtilHelper.ts
+++ b/runner/src/server/plugins/utils/UtilHelper.ts
@@ -11,6 +11,7 @@ export class UtilHelper {
       case BackLinkType.Eligibility:
         return isWelsh ? "Yn ôl at eich ceisiadau" : "Back to your applications";
       case BackLinkType.PreviousPage:
+        // TODO: Add Welsh translation for "Go back to previous page"
         return isWelsh ? "" : "Go back to previous page";
       case BackLinkType.ApplicationOverview:
         return isWelsh ? "Yn ôl i'r trosolwg o'r cais" : "Go back to application overview";

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -146,7 +146,7 @@
         {% endif %}
     {% endif %}
 
-    {% if page.backLink or backLink %}
+    {% if not previewMode and (page.backLink or backLink) %}
         {% if page.backLink %}
             {{ govukBackLink({
                 href: page.backLink,

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -22,7 +22,7 @@
             href: backLink or page.backLink,
             text: (backLinkText or page.backLinkText) if not isReadOnlySummary else "Back to application for funding overview"
         }) }}
-    {% elif page.backLink or backLink %}
+    {% elif not previewMode and (page.backLink or backLink) %}
         {% if page.backLink %}
             {{ govukBackLink({
                 href: page.backLink,

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -37,7 +37,7 @@
     {% endif %}
 {% endblock %}
 {% block content %}
-    <div class="govuk-main-wrapper">
+    <div class="govuk-main-wrapper govuk-!-static-padding-top-0">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 {% set hasMultipleSections = (details and details.length > 1 and details[0].items[0] | isArray) %}

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -22,6 +22,18 @@
             href: backLink or page.backLink,
             text: (backLinkText or page.backLinkText) if not isReadOnlySummary else "Back to application for funding overview"
         }) }}
+    {% elif page.backLink or backLink %}
+        {% if page.backLink %}
+            {{ govukBackLink({
+                href: page.backLink,
+                text: page.backLinkText
+            }) }}
+        {% else %}
+            {{ govukBackLink({
+                href: backLink,
+                text: backLinkText
+            }) }}
+        {% endif %}
     {% endif %}
 {% endblock %}
 {% block content %}

--- a/runner/test/cases/server/plugins/engine/page-controllers/ConfirmPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/ConfirmPageController.test.ts
@@ -70,6 +70,9 @@ suite("ConfirmPageController", () => {
             query: {
                 lang: "en"
             },
+            url: {
+                search: ""
+            },
             yar: {
                 get: sinon.stub().returns("en"),
                 flash: sinon.stub().returns("en")

--- a/runner/test/cases/server/plugins/engine/page-controllers/ConfirmPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/ConfirmPageController.test.ts
@@ -61,6 +61,7 @@ suite("ConfirmPageController", () => {
         // Mock adapterCacheService with the methods you need
         const mockAdapterCacheService: any = {
             getState: sinon.stub().resolves(mockState),
+            mergeState: sinon.stub().resolves(),
         };
         // Mock request with state
         const request = {

--- a/runner/test/cases/server/plugins/engine/page-controllers/SummaryPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/SummaryPageController.test.ts
@@ -117,6 +117,9 @@ suite("SummaryPageController", () => {
             query: {
                 lang: "en"
             },
+            url: {
+                search: ""
+            },
             yar: {
                 get: sinon.stub().returns("en"),
                 flash: sinon.stub().returns("en")

--- a/runner/test/cases/server/plugins/engine/page-controllers/SummaryPageController.test.ts
+++ b/runner/test/cases/server/plugins/engine/page-controllers/SummaryPageController.test.ts
@@ -108,6 +108,7 @@ suite("SummaryPageController", () => {
         // Mock adapterCacheService with the methods you need
         const mockAdapterCacheService: any = {
             getState: sinon.stub().resolves(mockState),
+            mergeState: sinon.stub().resolves(),
         };
         // Mock request with state
         const request = {


### PR DESCRIPTION
### Ticket  
🔗 https://mhclgdigital.atlassian.net/browse/FLS-1413

---

### **Pull Request Description**

This PR addresses accessibility audit recommendations by improving sequential navigation within the Apply service forms. Previously, all form pages displayed a backlink labeled **"Go back to application overview"** (Summary page didn't show backlink), which redirected users to the task list. This disrupted the expected step-by-step navigation experience.

#### ✅ Updated Behavior:
- **First page of the form**: Backlink text remains **"Go back to application overview"**.
- **Subsequent pages (including summary)**: Backlink text is now **"Go back to previous page"**, enabling users to navigate backward through the form sequentially.

#### 🔧 Technical Improvements:
- Refactored navigation logic into a shared utility (`navigationUtils`) for consistent behavior across controllers.
- Updated `pageControllerBase` and `summaryPageController` to use the shared utility.
- Added backlink rendering logic to `summary.html` using the GOV.UK Back Link component.
- Fixed failing unit and e2e tests by updating mock requests and URLs.

---

### **Change Summary**
- Introduced shared `navigationUtils` for backlink and progress logic.
- Updated backlink text and URL logic across form pages.
- Added backlink support to the summary page.
- Fixed and updated relevant tests.

---

### **How to Test**
1. Start an application for any fund in the Apply service.
2. Open a form and observe the backlink behavior:
   - ✅ On the **first page**, the backlink should say **"Go back to application overview"**.
   - ✅ On **subsequent pages**, including the summary page, it should say **"Go back to previous page"**.

---

### ✅ Checklist
- [x] Unit tests and other appropriate tests added or updated  
- [x] Commit messages follow good practices  

---

### 📸 Screen Recording of UI Changes  

https://github.com/user-attachments/assets/f8be2c35-a22e-4b42-82fd-952291b4b8bd