### PR TITLE
Bugfix - Ensure all file uploads correctly marked as complete when multiple files are uploaded in parallel

### DIFF
--- a/runner/src/server/plugins/engine/views/components/clientsidefileuploadfield.html
+++ b/runner/src/server/plugins/engine/views/components/clientsidefileuploadfield.html
@@ -407,7 +407,7 @@
         const updateProgressBarContent = (file, text) => {
             let tableFileUploadStatusIndicatorArea = file.previewElement.querySelector('.dz-progress-bar');
             if (!tableFileUploadStatusIndicatorArea) {
-                tableFileUploadStatusIndicatorArea = document.querySelector('[data-dz-uploadprogress]');
+                tableFileUploadStatusIndicatorArea = file.previewElement.querySelector('[data-dz-uploadprogress]');
                 if (tableFileUploadStatusIndicatorArea !== null) {
                     tableFileUploadStatusIndicatorArea.textContent = text;
                 }


### PR DESCRIPTION
### 🎫 Ticket

[Form Runner - only one uploaded file marked "Complete" on parallel file upload](https://mhclgdigital.atlassian.net/browse/FLS-1495)

### 🌍 Background

When multiple files are uploaded in parallel in a client-side file upload component, we were witnessing weird behaviour, whereby only the topmost file would have its status changed from "In progress" to "Complete" after virus scanning. This was only happening in deployed environments, not locally. Checking S3 revealed that files were being successfully uploaded in the backend.

The issue was that when we change the progress bar to the text "In progress" after file upload is complete but BEFORE the virus scan is successful, we lose the `.dz-progress-bar` class, and fallback to the code that looks for the `[data-dz-uploadprogress]` attribute. But because we use `document.querySelector`, we look globally, meaning the element we get back is the first element with that attribute, i.e., the element reading "In progress" or "Complete" for the topmost file. So we always update this element, meaning the rest stay as "In progress". By making the `querySelector` specific to the file, we eliminate this issue.

The reason it never failed locally was because we always returned an array of tags immediately as a mocked response, and so we never changed the progress bar to 'In progress' text, and so we never hit the dodgy fallback code.

### 🚧 Testing

As mentioned above, it never failed locally because we always returned an array of tags immediately. So the way I tested the fix locally was...

- Temporarily change the `s3CheckTagsAndDelete` handler code `else` block (hit when `config.enableVirusScan` is false, which it is locally) to this:

```
await new Promise(resolve => setTimeout(resolve, Math.random() * 3000));
const fileKey = `${key}`;
const pollCount = this.fileScanSimulation.get(fileKey) || 0;
this.fileScanSimulation.set(fileKey, pollCount + 1);
if (pollCount == 0) {
    return { tags: [] };
} else {
    this.fileScanSimulation.delete(fileKey);
    return {
        tags: [
            {
                Key: GUARD_DUTY_MALWARE_SCAN_STATUS,
                Value: NO_THREATS_FOUND
            }
        ]
    };
}
```
And add `private fileScanSimulation: Map<string, number> = new Map();` to the `RegisterS3FileUploadApi` class.

This basically [A] pauses the clock on the server for between 0 and 3 seconds, to simulate the arbitrary latency of an async request, and [B] returns an empty array on the first request, but a non-empty array on subsequent requests, ensuring we remove the progress bar on the frontend and replace it with the "In progress" text.
- With the original `clientsidefileuploadfield.html` code (from `main`) running, try uploading multiple files in parallel in the Form Runner. You'll need a form with a client-side file upload component that has both `maxFiles` and `parallelUploads` > 1, and watch it fail
- Run the latest `clientsidefileuploadfield.html` code (from this feature branch), try the same thing, and watch it succeed
