### PR TITLE
FLS-1518 - Runner - optionally hide section title completely from the summary page

### DIFF
--- a/runner/src/server/views/partials/summary-detail.html
+++ b/runner/src/server/views/partials/summary-detail.html
@@ -2,7 +2,7 @@
 
 {% macro summaryDetail(data, isReadOnlySummary=false) %}
     {%  set isRepeatableSection = (data.items[0] | isArray) %}
-    {% if not isRepeatableSection %}
+    {% if not isRepeatableSection and not data.hideTitle %}
         <h2 class="govuk-heading-m">{{data.title}}</h2>
     {% endif %}
   <dl class="govuk-summary-list">


### PR DESCRIPTION
### 🎫 Ticket

[Form Runner - remove the words "Default Section" from "Check your answers" page](https://mhclgdigital.atlassian.net/browse/FLS-1518)

### 🌍 Background

Currently if you set 'hideTitle' to 'true' in the form definition JSON, the section title that would otherwise have appeared above the main page heading is successfully hidden, however the section title still appears as h2 text just below the main page heading. In practice, this means users filling out application forms are seeing the meaningless words 'Default section' on every 'Check your answers' page.

### ♻️ Changes

This change ensures that we check the 'hideTitle' parameter to decide whether to render the section title as h2 text beneath the main page heading.

### 📸 Screenshots

**Before**

<img width="1916" height="970" alt="Screenshot 2025-09-24 at 15 46 00" src="https://github.com/user-attachments/assets/f61ae00c-e4d6-4975-9944-a839c3b897d7" />

---

**After**

<img width="1918" height="971" alt="Screenshot 2025-09-24 at 15 46 51" src="https://github.com/user-attachments/assets/3cfbcaef-4882-4f3e-8a43-4c2ecd52bd4e" />
