### PR TITLE
Bugfix - Client-side file upload field - remove make field optional checkbox + fix component validation in preview mode

### DIFF
--- a/designer/client/components/component-edit/AdapterFieldEdit.tsx
+++ b/designer/client/components/component-edit/AdapterFieldEdit.tsx
@@ -130,7 +130,7 @@ export const renderFieldEdit = (
                         }}
                     />
                 </div>
-                {!isContentField && type != "MultiInputField" && (
+                {!isContentField && type != "MultiInputField" && type != "ClientSideFileUploadField" && (
                     <div className="govuk-checkboxes govuk-form-group">
                         <div className="govuk-checkboxes__item">
                             <input

--- a/runner/src/server/plugins/engine/components/ClientSideFileUploadField.ts
+++ b/runner/src/server/plugins/engine/components/ClientSideFileUploadField.ts
@@ -33,8 +33,8 @@ export class ClientSideFileUploadField extends AdapterFormComponent {
                 const {s3UploadService, adapterCacheService} = request.services([]);
                 //@ts-ignore
                 const state = await adapterCacheService.getState(request);
-                const form_session_identifier =
-                    state.metadata?.form_session_identifier ?? "";
+                let form_session_identifier = state.metadata?.form_session_identifier ?? request.query.form_session_identifier ?? "";
+
                 const clientSideUploadComponent = viewModel.components.find(
                     (c) => c.type === "ClientSideFileUploadField"
                 );


### PR DESCRIPTION
### 🌍 Background

Content Designer Jenny flagged issues she noticed when previewing a form containing a client-side file upload component. Specifically:

> In Costs and value for money task, the question 'Upload your project budget with a breakdown of the key costs of your project' - this needs to be mandatory. I didn't select the checkbox 'Make Client side field upload field optional' which I thought would make it mandatory, but it looks like I can still skip the question. I then changed the default 'Minimum required files count' from 0 to 1 (as that seems like it would make it mandatory). This seemed to have worked in the sense that an error message now shows if there are no files uploaded, but the files I tried to upload would disappear and the error message doesn't go away

### 🔬 Investigation

There are two issues here - firstly, we have this ambiguity between the `required` and `minimumRequiredFiles` fields that you can set on the client-side file upload component in the Form Designer, with the `required` field being completely ignored by the Form Runner in practice. Secondly, we have the issue of the client-side file upload component validation not functioning properly once `minimumRequiredFiles` exceeds zero. This is only an issue when running forms in preview mode.

### ♻️ Changes

- **Designer - removing checkbox to make field optional from client-side file upload component configuration** - We currently have both a 'Make Client side field upload field optional' checkbox and a 'Minimum required files count' number field in the client-side file upload component configuration form. Having both creates ambiguity e.g., if we tick the checkbox to make it optional, but then set minimum required files to 1, or if we leave the checkbox unticked and set minimum required files to 0. Besides, on the Form Runner side we ignore the 'required' field (set by the checkbox) anyway, instead using the 'Minimum required files count'.
- **Runner - fixing client-side file upload component validation in preview mode** - Currently if you have a client-side file upload component with minimumRequiredFiles > 0, it is impossible to succesfully proceed past component validation when you are running the form in preview mode. This is because when we are looking for files to see if the minimumRequiredFiles threshold has been met, we build an S3 path with a form_session_identifier that doesn't exist because we're trying to take it from state.metadata, when in preview mode we need to take it from request.query (form_session_identifier is sent in the URL as one of the query parameters). This change adjusts client-side file upload component validation to fall back to taking form_session_identifier from the URL in cases where it's not available in the state.metadata, supporting both normal and preview workflows.

### 🚧 Testing

- Pull this branch locally
- Spin up FAB and Form Runner (see https://github.com/communitiesuk/funding-service-design-docker-runner)
- Download this file
[jROeKFqerF.json](https://github.com/user-attachments/files/22642069/jROeKFqerF.json) (this is the costs and value for money form mentioned by Jenny) and upload it in FAB as a template
- Click on the form preview link for the uploaded template in FAB
- Walk through the form pages until you reach the "Upload your project budget with a breakdown of the key costs of your project" page
- Try to proceed with no file uploaded, observe the validation error. Try to proceed with a file uploaded, observe the successful progression